### PR TITLE
feat: strengthen outbound to block unless action=allow

### DIFF
--- a/docs/hooks/prisma-airs-outbound.md
+++ b/docs/hooks/prisma-airs-outbound.md
@@ -44,7 +44,9 @@ plugins:
 
 ## Actions
 
-### Block
+Any AIRS response that is **not** `action: "allow"` is blocked. This includes both `block` and `warn` verdicts.
+
+### Block (default for non-allow)
 
 Replace the entire response with an error message:
 
@@ -56,7 +58,7 @@ After:  "I apologize, but I'm unable to provide that response
 
 ### Mask (DLP Only)
 
-When `dlp_mask_only: true` and only DLP violations detected:
+When `dlp_mask_only: true` and only DLP violations detected (no other threat categories):
 
 ```
 Before: "Your SSN is 123-45-6789 and card is 4111-1111-1111-1111"
@@ -65,7 +67,7 @@ After:  "Your SSN is [SSN REDACTED] and card is [CARD REDACTED]"
 
 ### Allow
 
-No modification.
+No modification. Only when AIRS returns `action: "allow"`.
 
 ## Masking Patterns
 
@@ -101,30 +103,21 @@ const handler = async (event, ctx) => {
     return; // Fail-open
   }
 
-  // Allow
+  // Only allow when AIRS explicitly says "allow"
   if (result.action === "allow") return;
 
-  // Warn - log but allow
-  if (result.action === "warn") {
-    console.log(JSON.stringify({ event: "prisma_airs_outbound_warn", ... }));
-    return;
-  }
-
-  // Block
-  if (result.action === "block") {
-    // Check if DLP-only (can mask instead of block)
-    if (shouldMaskOnly(result, config)) {
-      const masked = maskSensitiveData(content);
-      if (masked !== content) {
-        return { content: masked };
-      }
+  // Block or warn — check if DLP-only (can mask instead of block)
+  if (shouldMaskOnly(result, config)) {
+    const masked = maskSensitiveData(content);
+    if (masked !== content) {
+      return { content: masked };
     }
-
-    // Full block
-    return {
-      content: buildBlockMessage(result)
-    };
   }
+
+  // Full block — any non-allow action
+  return {
+    content: buildBlockMessage(result)
+  };
 };
 ```
 

--- a/prisma-airs-plugin/hooks/prisma-airs-outbound/handler.test.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-outbound/handler.test.ts
@@ -96,7 +96,7 @@ describe("prisma-airs-outbound handler", () => {
   });
 
   describe("warn action", () => {
-    it("should allow through with warning logged", async () => {
+    it("should block responses with warn action", async () => {
       mockScan.mockResolvedValue({
         action: "warn",
         severity: "MEDIUM",
@@ -113,8 +113,32 @@ describe("prisma-airs-outbound handler", () => {
       });
 
       const result = await handler(baseEvent, baseCtx);
-      expect(result).toBeUndefined();
-      expect(console.log).toHaveBeenCalled();
+      expect(result?.content).toContain("security policy");
+    });
+
+    it("should mask DLP-only warn responses when dlp_mask_only is true", async () => {
+      mockScan.mockResolvedValue({
+        action: "warn",
+        severity: "MEDIUM",
+        categories: ["dlp_response"],
+        scanId: "scan_123",
+        reportId: "report_456",
+        profileName: "default",
+        promptDetected: defaultPromptDetected(),
+        responseDetected: { ...defaultResponseDetected(), dlp: true },
+        latencyMs: 50,
+        timeout: false,
+        hasError: false,
+        contentErrors: [],
+      });
+
+      const eventWithSSN = {
+        ...baseEvent,
+        content: "Your SSN is 123-45-6789",
+      };
+
+      const result = await handler(eventWithSSN, baseCtx);
+      expect(result?.content).toContain("[SSN REDACTED]");
     });
   });
 

--- a/prisma-airs-plugin/hooks/prisma-airs-outbound/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-outbound/handler.ts
@@ -10,7 +10,7 @@
  * - Custom Topics: org-specific policy violations
  * - Grounding: hallucination detection
  *
- * CAN BLOCK via { cancel: true } or modify via { content: "..." }
+ * BLOCKS unless AIRS action is "allow". DLP-only results masked when dlp_mask_only is true.
  */
 
 import { scan, type ScanResult } from "../../src/scanner";
@@ -293,68 +293,51 @@ const handler = async (
     })
   );
 
-  // Handle allow - no modification needed
+  // Allow only when AIRS explicitly says "allow"
   if (result.action === "allow") {
     return;
   }
 
-  // Handle warn - log but allow through
-  if (result.action === "warn") {
-    console.log(
-      JSON.stringify({
-        event: "prisma_airs_outbound_warn",
-        timestamp: new Date().toISOString(),
-        sessionKey,
-        severity: result.severity,
-        categories: result.categories,
-        scanId: result.scanId,
-      })
-    );
-    return; // Allow through with warning logged
-  }
+  // Block or warn — check if we should mask instead of block (DLP-only)
+  if (shouldMaskOnly(result, config)) {
+    const maskedContent = maskSensitiveData(content);
 
-  // Handle block
-  if (result.action === "block") {
-    // Check if we should mask instead of block (DLP-only)
-    if (shouldMaskOnly(result, config)) {
-      const maskedContent = maskSensitiveData(content);
+    // Only return modified content if masking actually changed something
+    if (maskedContent !== content) {
+      console.log(
+        JSON.stringify({
+          event: "prisma_airs_outbound_mask",
+          timestamp: new Date().toISOString(),
+          sessionKey,
+          action: result.action,
+          categories: result.categories,
+          scanId: result.scanId,
+        })
+      );
 
-      // Only return modified content if masking actually changed something
-      if (maskedContent !== content) {
-        console.log(
-          JSON.stringify({
-            event: "prisma_airs_outbound_mask",
-            timestamp: new Date().toISOString(),
-            sessionKey,
-            categories: result.categories,
-            scanId: result.scanId,
-          })
-        );
-
-        return {
-          content: maskedContent,
-        };
-      }
+      return {
+        content: maskedContent,
+      };
     }
-
-    // Full block - replace content entirely
-    console.log(
-      JSON.stringify({
-        event: "prisma_airs_outbound_block",
-        timestamp: new Date().toISOString(),
-        sessionKey,
-        action: result.action,
-        severity: result.severity,
-        categories: result.categories,
-        scanId: result.scanId,
-        reportId: result.reportId,
-      })
-    );
-
-    return {
-      content: buildBlockMessage(result),
-    };
   }
+
+  // Full block - replace content entirely
+  console.log(
+    JSON.stringify({
+      event: "prisma_airs_outbound_block",
+      timestamp: new Date().toISOString(),
+      sessionKey,
+      action: result.action,
+      severity: result.severity,
+      categories: result.categories,
+      scanId: result.scanId,
+      reportId: result.reportId,
+    })
+  );
+
+  return {
+    content: buildBlockMessage(result),
+  };
 };
 
 export default handler;


### PR DESCRIPTION
## Summary

- Outbound handler now blocks on **any** non-allow action (block or warn)
- Previously `warn` actions were logged but allowed through — now they trigger blocking
- DLP masking preserved for DLP-only results regardless of action type
- Updated tests and docs

Closes #17

## Test plan

- [x] Test: warn action now blocks with security policy message
- [x] Test: warn+DLP masks instead of blocking when dlp_mask_only=true
- [x] All 89 tests pass (13 outbound handler tests)
- [x] Typecheck, lint, format clean