### PR TITLE
feat: hard inbound blocking via before_message_write

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,16 +1,17 @@
 # Hooks Overview
 
-The Prisma AIRS plugin provides 5 security hooks that work together for defense-in-depth.
+The Prisma AIRS plugin provides 6 security hooks that work together for defense-in-depth.
 
 ## Hook Summary
 
-| Hook                                            | Event                | Purpose                 | Can Block |
-| ----------------------------------------------- | -------------------- | ----------------------- | --------- |
-| [prisma-airs-guard](prisma-airs-guard.md)       | `before_agent_start` | Remind agents to scan   | No        |
-| [prisma-airs-audit](prisma-airs-audit.md)       | `message_received`   | Audit logging + caching | No        |
-| [prisma-airs-context](prisma-airs-context.md)   | `before_agent_start` | Inject threat warnings  | No\*      |
-| [prisma-airs-outbound](prisma-airs-outbound.md) | `message_sending`    | Block/mask responses    | Yes       |
-| [prisma-airs-tools](prisma-airs-tools.md)       | `before_tool_call`   | Block dangerous tools   | Yes       |
+| Hook                                                              | Event                  | Purpose                   | Can Block |
+| ----------------------------------------------------------------- | ---------------------- | ------------------------- | --------- |
+| [prisma-airs-guard](prisma-airs-guard.md)                         | `before_agent_start`   | Remind agents to scan     | No        |
+| [prisma-airs-audit](prisma-airs-audit.md)                         | `message_received`     | Audit logging + caching   | No        |
+| [prisma-airs-context](prisma-airs-context.md)                     | `before_agent_start`   | Inject threat warnings    | No\*      |
+| [prisma-airs-inbound-block](prisma-airs-inbound-block.md)         | `before_message_write` | Block unsafe user messages| Yes       |
+| [prisma-airs-outbound](prisma-airs-outbound.md)                   | `message_sending`      | Block/mask responses      | Yes       |
+| [prisma-airs-tools](prisma-airs-tools.md)                         | `before_tool_call`     | Block dangerous tools     | Yes       |
 
 \*Cannot block directly, but can influence agent behavior via context
 
@@ -60,6 +61,7 @@ plugins:
       reminder_mode: "on"              # prisma-airs-guard (on / off)
       audit_mode: "deterministic"      # prisma-airs-audit
       context_injection_mode: "deterministic"  # prisma-airs-context
+      inbound_block_mode: "deterministic"     # prisma-airs-inbound-block
       outbound_mode: "deterministic"   # prisma-airs-outbound
       tool_gating_mode: "deterministic" # prisma-airs-tools
 ```
@@ -93,6 +95,7 @@ plugins:
       reminder_mode: "on"
       audit_mode: "deterministic"
       context_injection_mode: "deterministic"
+      inbound_block_mode: "deterministic"
       outbound_mode: "deterministic"
       tool_gating_mode: "deterministic"
       dlp_mask_only: false # Block instead of mask

--- a/docs/hooks/prisma-airs-inbound-block.md
+++ b/docs/hooks/prisma-airs-inbound-block.md
@@ -1,0 +1,82 @@
+# prisma-airs-inbound-block
+
+Hard inbound blocking — prevents user messages from being persisted unless AIRS allows them.
+
+## Overview
+
+| Property      | Value                                                |
+| ------------- | ---------------------------------------------------- |
+| **Event**     | `before_message_write`                               |
+| **Emoji**     | :no_entry:                                           |
+| **Can Block** | Yes (`{ block: true }`)                              |
+| **Config**    | `inbound_block_mode`, `fail_closed`                  |
+
+## Purpose
+
+This hook:
+
+1. Fires **before** a message is written to conversation history
+2. Scans user messages through Prisma AIRS
+3. Blocks any message where AIRS does not return `action: "allow"`
+4. Blocked messages are never persisted — they never reach the AI model
+
+## Configuration
+
+```yaml
+plugins:
+  prisma-airs:
+    config:
+      inbound_block_mode: "deterministic" # default
+      fail_closed: true # Block on scan failure (default)
+```
+
+## Actions
+
+| AIRS Action | Result                           |
+| ----------- | -------------------------------- |
+| `allow`     | Message persisted normally       |
+| `warn`      | **Blocked** — message rejected   |
+| `block`     | **Blocked** — message rejected   |
+| (error)     | Blocked if `fail_closed: true`   |
+
+## Role Filtering
+
+Only **user** messages are scanned. Assistant messages are skipped (handled by the [outbound hook](prisma-airs-outbound.md)).
+
+## Audit Logging
+
+### Scan Result
+
+```json
+{
+  "event": "prisma_airs_inbound_block_scan",
+  "timestamp": "2024-01-15T10:30:00.000Z",
+  "sessionKey": "session_abc123",
+  "action": "allow",
+  "severity": "SAFE",
+  "categories": ["safe"],
+  "scanId": "scan_xyz789",
+  "latencyMs": 120
+}
+```
+
+### Block Event
+
+```json
+{
+  "event": "prisma_airs_inbound_block_rejected",
+  "timestamp": "2024-01-15T10:30:00.000Z",
+  "sessionKey": "session_abc123",
+  "action": "block",
+  "severity": "CRITICAL",
+  "categories": ["prompt_injection"],
+  "scanId": "scan_xyz789",
+  "reportId": "report_abc123"
+}
+```
+
+## Related Hooks
+
+- [prisma-airs-outbound](prisma-airs-outbound.md) — Outbound (assistant) message blocking
+- [prisma-airs-audit](prisma-airs-audit.md) — Inbound scanning with audit logging
+- [prisma-airs-guard](prisma-airs-guard.md) — Agent bootstrap security reminder

--- a/prisma-airs-plugin/hooks/prisma-airs-inbound-block/HOOK.md
+++ b/prisma-airs-plugin/hooks/prisma-airs-inbound-block/HOOK.md
@@ -1,0 +1,23 @@
+---
+name: prisma-airs-inbound-block
+description: "Block inbound user messages that fail Prisma AIRS security scanning"
+metadata: { "openclaw": { "emoji": "🚫", "events": ["before_message_write"] } }
+---
+
+# Prisma AIRS Inbound Blocking
+
+Hard guardrail that prevents user messages from being persisted unless AIRS returns `action: "allow"`.
+
+## Behavior
+
+This hook fires **before** a message is written to the conversation. It scans user messages through Prisma AIRS and blocks any that do not receive an explicit "allow" verdict. Blocked messages never reach the AI model.
+
+## Configuration
+
+- `inbound_block_mode`: Scanning mode (default: `deterministic`). Options: `deterministic` / `off`
+- `fail_closed`: Block on scan failure (default: true)
+
+## Return Value
+
+- `{ block: true }` — message is rejected, never persisted
+- `{ block: false }` or `void` — message is allowed through

--- a/prisma-airs-plugin/hooks/prisma-airs-inbound-block/handler.test.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-inbound-block/handler.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for prisma-airs-inbound-block hook handler
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import handler from "./handler";
+
+// Mock the scanner module
+vi.mock("../../src/scanner", () => ({
+  scan: vi.fn(),
+  defaultPromptDetected: () => ({
+    injection: false,
+    dlp: false,
+    urlCats: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    topicViolation: false,
+  }),
+  defaultResponseDetected: () => ({
+    dlp: false,
+    urlCats: false,
+    dbSecurity: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    ungrounded: false,
+    topicViolation: false,
+  }),
+}));
+
+import { scan, defaultPromptDetected, defaultResponseDetected } from "../../src/scanner";
+const mockScan = vi.mocked(scan);
+
+describe("prisma-airs-inbound-block handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const baseEvent = {
+    content: "Hello, how are you?",
+    role: "user" as const,
+    metadata: {
+      sessionKey: "test-session",
+    },
+  };
+
+  const baseCtx = {
+    channelId: "slack",
+    conversationId: "conv-123",
+    cfg: {
+      plugins: {
+        entries: {
+          "prisma-airs": {
+            config: {
+              profile_name: "default",
+              app_name: "test-app",
+              fail_closed: true,
+              inbound_block_mode: "deterministic",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const allowResult = {
+    action: "allow" as const,
+    severity: "SAFE" as const,
+    categories: ["safe"],
+    scanId: "scan_123",
+    reportId: "report_456",
+    profileName: "default",
+    promptDetected: defaultPromptDetected(),
+    responseDetected: defaultResponseDetected(),
+    latencyMs: 50,
+    timeout: false,
+    hasError: false,
+    contentErrors: [],
+  };
+
+  describe("allow action", () => {
+    it("should not block allowed messages", async () => {
+      mockScan.mockResolvedValue(allowResult);
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result).toBeUndefined();
+      expect(mockScan).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("block action", () => {
+    it("should block messages with block action", async () => {
+      mockScan.mockResolvedValue({
+        ...allowResult,
+        action: "block",
+        severity: "CRITICAL",
+        categories: ["prompt_injection"],
+      });
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result).toEqual({ block: true });
+    });
+
+    it("should block messages with warn action", async () => {
+      mockScan.mockResolvedValue({
+        ...allowResult,
+        action: "warn",
+        severity: "MEDIUM",
+        categories: ["url_filtering_prompt"],
+      });
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result).toEqual({ block: true });
+    });
+  });
+
+  describe("role filtering", () => {
+    it("should skip assistant messages", async () => {
+      const assistantEvent = { ...baseEvent, role: "assistant" as const };
+
+      const result = await handler(assistantEvent, baseCtx);
+      expect(result).toBeUndefined();
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+
+    it("should scan user messages", async () => {
+      mockScan.mockResolvedValue(allowResult);
+
+      await handler(baseEvent, baseCtx);
+      expect(mockScan).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("empty content", () => {
+    it("should skip empty content", async () => {
+      const emptyEvent = { ...baseEvent, content: "" };
+      const result = await handler(emptyEvent, baseCtx);
+      expect(result).toBeUndefined();
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+
+    it("should skip undefined content", async () => {
+      const noContentEvent = { ...baseEvent, content: undefined };
+      const result = await handler(noContentEvent, baseCtx);
+      expect(result).toBeUndefined();
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fail-closed behavior", () => {
+    it("should block on scan failure when fail_closed is true", async () => {
+      mockScan.mockRejectedValue(new Error("API timeout"));
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result).toEqual({ block: true });
+    });
+
+    it("should allow through on scan failure when fail_closed is false", async () => {
+      mockScan.mockRejectedValue(new Error("API timeout"));
+
+      const ctxFailOpen = {
+        ...baseCtx,
+        cfg: {
+          plugins: {
+            entries: {
+              "prisma-airs": {
+                config: {
+                  ...baseCtx.cfg.plugins.entries["prisma-airs"].config,
+                  fail_closed: false,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = await handler(baseEvent, ctxFailOpen);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("disabled mode", () => {
+    it("should skip scanning when inbound_block_mode is off", async () => {
+      const ctxOff = {
+        ...baseCtx,
+        cfg: {
+          plugins: {
+            entries: {
+              "prisma-airs": {
+                config: {
+                  ...baseCtx.cfg.plugins.entries["prisma-airs"].config,
+                  inbound_block_mode: "off",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = await handler(baseEvent, ctxOff);
+      expect(result).toBeUndefined();
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("scan request", () => {
+    it("should scan with prompt field from message content", async () => {
+      mockScan.mockResolvedValue(allowResult);
+
+      await handler(baseEvent, baseCtx);
+
+      expect(mockScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "Hello, how are you?",
+          profileName: "default",
+          appName: "test-app",
+        })
+      );
+    });
+  });
+});

--- a/prisma-airs-plugin/hooks/prisma-airs-inbound-block/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-inbound-block/handler.ts
@@ -1,0 +1,151 @@
+/**
+ * Prisma AIRS Inbound Blocking (before_message_write)
+ *
+ * Hard guardrail: blocks user messages unless AIRS returns action "allow".
+ * Blocked messages are never persisted to conversation history.
+ */
+
+import { scan } from "../../src/scanner";
+
+// Event shape from OpenClaw before_message_write hook
+interface MessageWriteEvent {
+  content?: string;
+  role?: string;
+  metadata?: {
+    sessionKey?: string;
+    messageId?: string;
+  };
+}
+
+// Context passed to hook
+interface HookContext {
+  channelId?: string;
+  accountId?: string;
+  conversationId?: string;
+  cfg?: PluginConfig;
+}
+
+// Plugin config structure
+interface PluginConfig {
+  plugins?: {
+    entries?: {
+      "prisma-airs"?: {
+        config?: {
+          profile_name?: string;
+          app_name?: string;
+          fail_closed?: boolean;
+          inbound_block_mode?: string;
+        };
+      };
+    };
+  };
+}
+
+// Hook result type
+interface HookResult {
+  block: boolean;
+}
+
+/**
+ * Get plugin configuration
+ */
+function getPluginConfig(ctx: HookContext): {
+  profileName: string;
+  appName: string;
+  failClosed: boolean;
+  mode: string;
+} {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
+  return {
+    profileName: cfg?.profile_name ?? "default",
+    appName: cfg?.app_name ?? "openclaw",
+    failClosed: cfg?.fail_closed ?? true,
+    mode: cfg?.inbound_block_mode ?? "deterministic",
+  };
+}
+
+/**
+ * Main hook handler
+ */
+const handler = async (event: MessageWriteEvent, ctx: HookContext): Promise<HookResult | void> => {
+  const config = getPluginConfig(ctx);
+
+  // Skip if disabled
+  if (config.mode === "off") {
+    return;
+  }
+
+  // Only scan user messages — assistant messages handled by outbound hook
+  if (event.role !== "user") {
+    return;
+  }
+
+  // Validate content
+  const content = event.content;
+  if (!content || typeof content !== "string" || content.trim().length === 0) {
+    return;
+  }
+
+  const sessionKey = event.metadata?.sessionKey || ctx.conversationId || "unknown";
+
+  try {
+    const result = await scan({
+      prompt: content,
+      profileName: config.profileName,
+      appName: config.appName,
+    });
+
+    // Log scan result
+    console.log(
+      JSON.stringify({
+        event: "prisma_airs_inbound_block_scan",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        action: result.action,
+        severity: result.severity,
+        categories: result.categories,
+        scanId: result.scanId,
+        latencyMs: result.latencyMs,
+      })
+    );
+
+    // Only allow when AIRS explicitly says "allow"
+    if (result.action === "allow") {
+      return;
+    }
+
+    // Block — message will not be persisted
+    console.log(
+      JSON.stringify({
+        event: "prisma_airs_inbound_block_rejected",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        action: result.action,
+        severity: result.severity,
+        categories: result.categories,
+        scanId: result.scanId,
+        reportId: result.reportId,
+      })
+    );
+
+    return { block: true };
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: "prisma_airs_inbound_block_error",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+
+    // Fail-closed: block on scan failure
+    if (config.failClosed) {
+      return { block: true };
+    }
+
+    return; // Fail-open
+  }
+};
+
+export default handler;

--- a/prisma-airs-plugin/openclaw.plugin.json
+++ b/prisma-airs-plugin/openclaw.plugin.json
@@ -9,7 +9,8 @@
     "hooks/prisma-airs-audit",
     "hooks/prisma-airs-context",
     "hooks/prisma-airs-outbound",
-    "hooks/prisma-airs-tools"
+    "hooks/prisma-airs-tools",
+    "hooks/prisma-airs-inbound-block"
   ],
   "configSchema": {
     "type": "object",
@@ -54,6 +55,12 @@
         "enum": ["deterministic", "probabilistic", "off"],
         "default": "deterministic",
         "description": "Tool gating mode: deterministic (hook, always gate), probabilistic (tool, model decides), or off"
+      },
+      "inbound_block_mode": {
+        "type": "string",
+        "enum": ["deterministic", "off"],
+        "default": "deterministic",
+        "description": "Inbound blocking mode: deterministic (block non-allow user messages), or off"
       },
       "fail_closed": {
         "type": "boolean",
@@ -121,6 +128,10 @@
     "tool_gating_mode": {
       "label": "Tool Gating Mode",
       "description": "deterministic: always gate tool calls via hook; probabilistic: model checks tool safety via tool; off: disabled"
+    },
+    "inbound_block_mode": {
+      "label": "Inbound Blocking Mode",
+      "description": "deterministic: block user messages unless AIRS returns allow; off: disabled"
     },
     "fail_closed": {
       "label": "Fail Closed",


### PR DESCRIPTION
## Summary

- New `prisma-airs-inbound-block` hook blocks user messages at persistence layer unless AIRS returns `action: "allow"`
- Uses `before_message_write` event — blocked messages never reach conversation history or AI model
- Only scans user-role messages (assistant handled by outbound hook)
- Configurable: `inbound_block_mode` (deterministic/off), `fail_closed` (default true)
- 11 new tests, 100 total across 6 test files

Closes #15

## Test plan

- [x] Blocks messages with block action
- [x] Blocks messages with warn action
- [x] Allows messages with allow action
- [x] Skips assistant messages
- [x] Skips empty content
- [x] Fail-closed on scan errors (configurable)
- [x] Respects inbound_block_mode=off
- [x] Passes correct scan request params
- [x] All 100 tests pass, all quality gates clean