### PR TITLE
feat: scan tool inputs through AIRS via before_tool_call

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,6 +1,6 @@
 # Hooks Overview
 
-The Prisma AIRS plugin provides 7 security hooks that work together for defense-in-depth.
+The Prisma AIRS plugin provides 8 security hooks that work together for defense-in-depth.
 
 ## Hook Summary
 
@@ -12,7 +12,8 @@ The Prisma AIRS plugin provides 7 security hooks that work together for defense-
 | [prisma-airs-inbound-block](prisma-airs-inbound-block.md)         | `before_message_write` | Block unsafe user messages   | Yes       |
 | [prisma-airs-outbound-block](prisma-airs-outbound-block.md)       | `before_message_write` | Block unsafe assistant msgs  | Yes       |
 | [prisma-airs-outbound](prisma-airs-outbound.md)                   | `message_sending`      | Block/mask responses         | Yes       |
-| [prisma-airs-tools](prisma-airs-tools.md)                         | `before_tool_call`     | Block dangerous tools        | Yes       |
+| [prisma-airs-tools](prisma-airs-tools.md)                         | `before_tool_call`     | Block tools (cached result)  | Yes       |
+| [prisma-airs-tool-guard](prisma-airs-tool-guard.md)               | `before_tool_call`     | Scan tool inputs via AIRS    | Yes       |
 
 \*Cannot block directly, but can influence agent behavior via context
 
@@ -65,7 +66,8 @@ plugins:
       inbound_block_mode: "deterministic"      # prisma-airs-inbound-block
       outbound_block_mode: "deterministic"    # prisma-airs-outbound-block
       outbound_mode: "deterministic"          # prisma-airs-outbound
-      tool_gating_mode: "deterministic" # prisma-airs-tools
+      tool_gating_mode: "deterministic"       # prisma-airs-tools
+      tool_guard_mode: "deterministic"        # prisma-airs-tool-guard
 ```
 
 ## Data Sharing
@@ -101,6 +103,7 @@ plugins:
       outbound_block_mode: "deterministic"
       outbound_mode: "deterministic"
       tool_gating_mode: "deterministic"
+      tool_guard_mode: "deterministic"
       dlp_mask_only: false # Block instead of mask
 ```
 

--- a/docs/hooks/prisma-airs-tool-guard.md
+++ b/docs/hooks/prisma-airs-tool-guard.md
@@ -1,0 +1,74 @@
+# prisma-airs-tool-guard
+
+Active tool input scanning — scans tool call inputs through AIRS before execution.
+
+## Overview
+
+| Property      | Value                                                |
+| ------------- | ---------------------------------------------------- |
+| **Event**     | `before_tool_call`                                   |
+| **Emoji**     | :lock:                                               |
+| **Can Block** | Yes (`{ block: true, blockReason }`)                 |
+| **Config**    | `tool_guard_mode`, `fail_closed`                     |
+
+## Purpose
+
+This hook:
+
+1. Fires **before** each tool call
+2. Builds a `toolEvent` with the tool's metadata and serialized arguments
+3. Scans the tool event through Prisma AIRS
+4. Blocks execution unless AIRS returns `action: "allow"`
+
+## How It Differs from prisma-airs-tools
+
+| Feature | prisma-airs-tools | prisma-airs-tool-guard |
+| ------- | ----------------- | ---------------------- |
+| Data source | Cached scan result | Active AIRS scan |
+| Scans | Cached inbound result | Tool input via toolEvent |
+| Latency | ~0ms (cache lookup) | AIRS API round-trip |
+| Coverage | Threats in original message | Threats in tool arguments |
+
+Use **both** for defense-in-depth: `prisma-airs-tools` catches threats from the conversation, `prisma-airs-tool-guard` catches threats in tool arguments.
+
+## Configuration
+
+```yaml
+plugins:
+  prisma-airs:
+    config:
+      tool_guard_mode: "deterministic" # default
+      fail_closed: true # Block on scan failure (default)
+```
+
+## Tool Event Structure
+
+The hook constructs a `toolEvent` for the AIRS scan:
+
+```json
+{
+  "toolEvents": [{
+    "metadata": {
+      "ecosystem": "mcp",
+      "method": "tool_call",
+      "serverName": "filesystem",
+      "toolInvoked": "read_file"
+    },
+    "input": "{\"path\":\"/etc/passwd\"}"
+  }]
+}
+```
+
+## Actions
+
+| AIRS Action | Result                              |
+| ----------- | ----------------------------------- |
+| `allow`     | Tool execution proceeds             |
+| `warn`      | **Blocked** — tool call rejected    |
+| `block`     | **Blocked** — tool call rejected    |
+| (error)     | Blocked if `fail_closed: true`      |
+
+## Related Hooks
+
+- [prisma-airs-tools](prisma-airs-tools.md) — Cache-based tool gating
+- [prisma-airs-inbound-block](prisma-airs-inbound-block.md) — User message blocking

--- a/prisma-airs-plugin/hooks/prisma-airs-tool-guard/HOOK.md
+++ b/prisma-airs-plugin/hooks/prisma-airs-tool-guard/HOOK.md
@@ -1,0 +1,23 @@
+---
+name: prisma-airs-tool-guard
+description: "Scan tool inputs through Prisma AIRS using toolEvent content type before execution"
+metadata: { "openclaw": { "emoji": "🔒", "events": ["before_tool_call"] } }
+---
+
+# Prisma AIRS Tool Guard
+
+Scans tool call inputs through Prisma AIRS using the `toolEvent` content type before execution. Blocks tools when AIRS does not return `action: "allow"`.
+
+## Behavior
+
+Unlike `prisma-airs-tools` (which uses cached scan results), this hook actively scans each tool call's input through the AIRS API. It builds a `toolEvent` with the tool's metadata and arguments, then blocks execution if the scan returns a non-allow verdict.
+
+## Configuration
+
+- `tool_guard_mode`: Scanning mode (default: `deterministic`). Options: `deterministic` / `off`
+- `fail_closed`: Block on scan failure (default: true)
+
+## Return Value
+
+- `{ block: true, blockReason: "..." }` — tool call rejected
+- `void` — tool call allowed

--- a/prisma-airs-plugin/hooks/prisma-airs-tool-guard/handler.test.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-tool-guard/handler.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for prisma-airs-tool-guard hook handler
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import handler from "./handler";
+
+// Mock the scanner module
+vi.mock("../../src/scanner", () => ({
+  scan: vi.fn(),
+  defaultPromptDetected: () => ({
+    injection: false,
+    dlp: false,
+    urlCats: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    topicViolation: false,
+  }),
+  defaultResponseDetected: () => ({
+    dlp: false,
+    urlCats: false,
+    dbSecurity: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    ungrounded: false,
+    topicViolation: false,
+  }),
+}));
+
+import { scan, defaultPromptDetected, defaultResponseDetected } from "../../src/scanner";
+const mockScan = vi.mocked(scan);
+
+describe("prisma-airs-tool-guard handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const baseEvent = {
+    toolName: "read_file",
+    toolId: "tool-123",
+    serverName: "filesystem",
+    params: { path: "/etc/passwd" },
+  };
+
+  const baseCtx = {
+    channelId: "slack",
+    conversationId: "conv-123",
+    cfg: {
+      plugins: {
+        entries: {
+          "prisma-airs": {
+            config: {
+              profile_name: "default",
+              app_name: "test-app",
+              fail_closed: true,
+              tool_guard_mode: "deterministic",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const allowResult = {
+    action: "allow" as const,
+    severity: "SAFE" as const,
+    categories: ["safe"],
+    scanId: "scan_123",
+    reportId: "report_456",
+    profileName: "default",
+    promptDetected: defaultPromptDetected(),
+    responseDetected: defaultResponseDetected(),
+    latencyMs: 50,
+    timeout: false,
+    hasError: false,
+    contentErrors: [],
+  };
+
+  describe("allow action", () => {
+    it("should not block allowed tool calls", async () => {
+      mockScan.mockResolvedValue(allowResult);
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result).toBeUndefined();
+      expect(mockScan).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("block action", () => {
+    it("should block tool calls with block action", async () => {
+      mockScan.mockResolvedValue({
+        ...allowResult,
+        action: "block",
+        severity: "CRITICAL",
+        categories: ["malicious_code_prompt"],
+      });
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result?.block).toBe(true);
+      expect(result?.blockReason).toContain("read_file");
+      expect(result?.blockReason).toContain("malicious_code_prompt");
+    });
+
+    it("should block tool calls with warn action", async () => {
+      mockScan.mockResolvedValue({
+        ...allowResult,
+        action: "warn",
+        severity: "MEDIUM",
+        categories: ["agent_threat_prompt"],
+      });
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result?.block).toBe(true);
+    });
+  });
+
+  describe("tool event construction", () => {
+    it("should pass toolEvents with metadata to scan", async () => {
+      mockScan.mockResolvedValue(allowResult);
+
+      await handler(baseEvent, baseCtx);
+
+      expect(mockScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolEvents: [
+            expect.objectContaining({
+              metadata: expect.objectContaining({
+                ecosystem: "mcp",
+                method: "tool_call",
+                serverName: "filesystem",
+                toolInvoked: "read_file",
+              }),
+              input: JSON.stringify({ path: "/etc/passwd" }),
+            }),
+          ],
+        })
+      );
+    });
+
+    it("should use 'unknown' for missing server name", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      const eventNoServer = { ...baseEvent, serverName: undefined };
+
+      await handler(eventNoServer, baseCtx);
+
+      expect(mockScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolEvents: [
+            expect.objectContaining({
+              metadata: expect.objectContaining({
+                serverName: "unknown",
+              }),
+            }),
+          ],
+        })
+      );
+    });
+  });
+
+  describe("empty tool name", () => {
+    it("should skip when no tool name", async () => {
+      const noToolEvent = { ...baseEvent, toolName: "" };
+      const result = await handler(noToolEvent, baseCtx);
+      expect(result).toBeUndefined();
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fail-closed behavior", () => {
+    it("should block on scan failure when fail_closed is true", async () => {
+      mockScan.mockRejectedValue(new Error("API timeout"));
+
+      const result = await handler(baseEvent, baseCtx);
+      expect(result?.block).toBe(true);
+      expect(result?.blockReason).toContain("security scan failed");
+    });
+
+    it("should allow through on scan failure when fail_closed is false", async () => {
+      mockScan.mockRejectedValue(new Error("API timeout"));
+
+      const ctxFailOpen = {
+        ...baseCtx,
+        cfg: {
+          plugins: {
+            entries: {
+              "prisma-airs": {
+                config: {
+                  ...baseCtx.cfg.plugins.entries["prisma-airs"].config,
+                  fail_closed: false,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = await handler(baseEvent, ctxFailOpen);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("disabled mode", () => {
+    it("should skip scanning when tool_guard_mode is off", async () => {
+      const ctxOff = {
+        ...baseCtx,
+        cfg: {
+          plugins: {
+            entries: {
+              "prisma-airs": {
+                config: {
+                  ...baseCtx.cfg.plugins.entries["prisma-airs"].config,
+                  tool_guard_mode: "off",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = await handler(baseEvent, ctxOff);
+      expect(result).toBeUndefined();
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/prisma-airs-plugin/hooks/prisma-airs-tool-guard/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-tool-guard/handler.ts
@@ -1,0 +1,172 @@
+/**
+ * Prisma AIRS Tool Guard (before_tool_call)
+ *
+ * Actively scans tool call inputs through AIRS using the toolEvent content type.
+ * Blocks tool execution unless AIRS returns action "allow".
+ */
+
+import { scan } from "../../src/scanner";
+
+// Event shape from OpenClaw before_tool_call hook
+interface BeforeToolCallEvent {
+  toolName: string;
+  toolId?: string;
+  serverName?: string;
+  params?: Record<string, unknown>;
+}
+
+// Context passed to hook
+interface HookContext {
+  sessionKey?: string;
+  channelId?: string;
+  conversationId?: string;
+  cfg?: PluginConfig;
+}
+
+// Plugin config structure
+interface PluginConfig {
+  plugins?: {
+    entries?: {
+      "prisma-airs"?: {
+        config?: {
+          profile_name?: string;
+          app_name?: string;
+          fail_closed?: boolean;
+          tool_guard_mode?: string;
+        };
+      };
+    };
+  };
+}
+
+// Hook result type
+interface HookResult {
+  block?: boolean;
+  blockReason?: string;
+}
+
+/**
+ * Get plugin configuration
+ */
+function getPluginConfig(ctx: HookContext): {
+  profileName: string;
+  appName: string;
+  failClosed: boolean;
+  mode: string;
+} {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
+  return {
+    profileName: cfg?.profile_name ?? "default",
+    appName: cfg?.app_name ?? "openclaw",
+    failClosed: cfg?.fail_closed ?? true,
+    mode: cfg?.tool_guard_mode ?? "deterministic",
+  };
+}
+
+/**
+ * Main hook handler
+ */
+const handler = async (
+  event: BeforeToolCallEvent,
+  ctx: HookContext
+): Promise<HookResult | void> => {
+  const config = getPluginConfig(ctx);
+
+  // Skip if disabled
+  if (config.mode === "off") {
+    return;
+  }
+
+  // Validate tool name
+  if (!event.toolName) {
+    return;
+  }
+
+  const sessionKey = ctx.sessionKey || ctx.conversationId || "unknown";
+  const inputStr = event.params ? JSON.stringify(event.params) : undefined;
+
+  try {
+    const result = await scan({
+      profileName: config.profileName,
+      appName: config.appName,
+      toolEvents: [
+        {
+          metadata: {
+            ecosystem: "mcp",
+            method: "tool_call",
+            serverName: event.serverName ?? "unknown",
+            toolInvoked: event.toolName,
+          },
+          input: inputStr,
+        },
+      ],
+    });
+
+    // Log scan result
+    console.log(
+      JSON.stringify({
+        event: "prisma_airs_tool_guard_scan",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        toolName: event.toolName,
+        toolId: event.toolId,
+        action: result.action,
+        severity: result.severity,
+        categories: result.categories,
+        scanId: result.scanId,
+        latencyMs: result.latencyMs,
+      })
+    );
+
+    // Only allow when AIRS explicitly says "allow"
+    if (result.action === "allow") {
+      return;
+    }
+
+    // Block tool execution
+    const categories = result.categories.filter((c) => c !== "safe" && c !== "benign").join(", ");
+
+    console.log(
+      JSON.stringify({
+        event: "prisma_airs_tool_guard_block",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        toolName: event.toolName,
+        toolId: event.toolId,
+        action: result.action,
+        severity: result.severity,
+        categories: result.categories,
+        scanId: result.scanId,
+        reportId: result.reportId,
+      })
+    );
+
+    return {
+      block: true,
+      blockReason:
+        `Tool '${event.toolName}' blocked by security scan: ${categories || "threat detected"}. ` +
+        `Scan ID: ${result.scanId || "N/A"}`,
+    };
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: "prisma_airs_tool_guard_error",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        toolName: event.toolName,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+
+    if (config.failClosed) {
+      return {
+        block: true,
+        blockReason: `Tool '${event.toolName}' blocked: security scan failed. Try again later.`,
+      };
+    }
+
+    return; // Fail-open
+  }
+};
+
+export default handler;

--- a/prisma-airs-plugin/openclaw.plugin.json
+++ b/prisma-airs-plugin/openclaw.plugin.json
@@ -11,7 +11,8 @@
     "hooks/prisma-airs-outbound",
     "hooks/prisma-airs-tools",
     "hooks/prisma-airs-inbound-block",
-    "hooks/prisma-airs-outbound-block"
+    "hooks/prisma-airs-outbound-block",
+    "hooks/prisma-airs-tool-guard"
   ],
   "configSchema": {
     "type": "object",
@@ -68,6 +69,12 @@
         "enum": ["deterministic", "off"],
         "default": "deterministic",
         "description": "Outbound blocking mode: deterministic (block non-allow assistant messages at persistence layer), or off"
+      },
+      "tool_guard_mode": {
+        "type": "string",
+        "enum": ["deterministic", "off"],
+        "default": "deterministic",
+        "description": "Tool guard mode: deterministic (scan tool inputs through AIRS before execution), or off"
       },
       "fail_closed": {
         "type": "boolean",
@@ -143,6 +150,10 @@
     "outbound_block_mode": {
       "label": "Outbound Blocking Mode",
       "description": "deterministic: block assistant messages at persistence layer unless AIRS returns allow; off: disabled"
+    },
+    "tool_guard_mode": {
+      "label": "Tool Guard Mode",
+      "description": "deterministic: scan tool inputs through AIRS before execution; off: disabled"
     },
     "fail_closed": {
       "label": "Fail Closed",


### PR DESCRIPTION
## Summary

- New `prisma-airs-tool-guard` hook scans tool call inputs through AIRS using `toolEvent` content type
- Builds toolEvent with metadata (ecosystem, method, server_name, tool_invoked) + serialized arguments
- Blocks tool execution unless AIRS returns `action: "allow"`
- Complements existing `prisma-airs-tools` (cache-based gating) with active per-call scanning
- 9 new tests, 120 total across 8 test files

Closes #18

## Test plan

- [x] Blocks tools with block action
- [x] Blocks tools with warn action
- [x] Allows tools with allow action
- [x] Constructs proper toolEvent metadata
- [x] Handles missing server name
- [x] Skips empty tool name
- [x] Fail-closed on scan errors (configurable)
- [x] Respects tool_guard_mode=off
- [x] All 120 tests pass, all quality gates clean