### PR TITLE
feat: add LLM I/O audit logging via llm_input/llm_output hooks

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,6 +1,6 @@
 # Hooks Overview
 
-The Prisma AIRS plugin provides 10 security hooks that work together for defense-in-depth.
+The Prisma AIRS plugin provides 11 security hooks that work together for defense-in-depth.
 
 ## Hook Summary
 
@@ -16,6 +16,7 @@ The Prisma AIRS plugin provides 10 security hooks that work together for defense
 | [prisma-airs-tools](prisma-airs-tools.md)                         | `before_tool_call`     | Block tools (cached result)     | Yes       |
 | [prisma-airs-tool-guard](prisma-airs-tool-guard.md)               | `before_tool_call`     | Scan tool inputs via AIRS       | Yes       |
 | [prisma-airs-tool-redact](prisma-airs-tool-redact.md)             | `tool_result_persist`  | Redact PII from tool outputs    | No\*\*\*  |
+| [prisma-airs-llm-audit](prisma-airs-llm-audit.md)                | `llm_input/llm_output` | Audit log LLM I/O              | No        |
 
 \*\*\*Modifies persisted message content — does not block tool execution
 
@@ -75,6 +76,7 @@ plugins:
       tool_gating_mode: "deterministic"       # prisma-airs-tools
       tool_guard_mode: "deterministic"        # prisma-airs-tool-guard
       tool_redact_mode: "deterministic"       # prisma-airs-tool-redact
+      llm_audit_mode: "deterministic"         # prisma-airs-llm-audit
 ```
 
 ## Data Sharing
@@ -112,6 +114,7 @@ plugins:
       tool_gating_mode: "deterministic"
       tool_guard_mode: "deterministic"
       tool_redact_mode: "deterministic"
+      llm_audit_mode: "deterministic"
       dlp_mask_only: false # Block instead of mask
 ```
 

--- a/docs/hooks/prisma-airs-llm-audit.md
+++ b/docs/hooks/prisma-airs-llm-audit.md
@@ -1,0 +1,80 @@
+# prisma-airs-llm-audit
+
+Audit logging of LLM inputs and outputs through Prisma AIRS scanning.
+
+## Overview
+
+| Property      | Value                                               |
+| ------------- | --------------------------------------------------- |
+| **Events**    | `llm_input`, `llm_output`                           |
+| **Emoji**     | :clipboard:                                         |
+| **Can Block** | No (fire-and-forget)                                |
+| **Config**    | `llm_audit_mode`                                    |
+
+## Purpose
+
+This hook:
+
+1. Fires on `llm_input` — immediately before the prompt is sent to the LLM
+2. Fires on `llm_output` — immediately after the response is received from the LLM
+3. Scans the exact LLM I/O through Prisma AIRS
+4. Logs structured JSON audit entries with scan results, model info, and token usage
+5. Provides the definitive audit record at the LLM boundary
+
+## Why LLM Boundary Auditing Matters
+
+Other hooks scan at the application layer (user messages, tool calls, responses). But the actual content sent to and received from the LLM may differ due to context injection, prompt assembly, and response processing. This hook captures the ground truth of what the model saw and produced.
+
+## Configuration
+
+```yaml
+plugins:
+  prisma-airs:
+    config:
+      llm_audit_mode: "deterministic" # default
+```
+
+## Audit Log Format
+
+### llm_input
+
+```json
+{
+  "event": "prisma_airs_llm_input_audit",
+  "timestamp": "2025-01-01T00:00:00.000Z",
+  "sessionKey": "session-123",
+  "runId": "run-1",
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "action": "allow",
+  "severity": "SAFE",
+  "categories": ["safe"],
+  "scanId": "scan_abc",
+  "latencyMs": 45
+}
+```
+
+### llm_output
+
+```json
+{
+  "event": "prisma_airs_llm_output_audit",
+  "timestamp": "2025-01-01T00:00:00.000Z",
+  "sessionKey": "session-123",
+  "runId": "run-1",
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "action": "allow",
+  "severity": "SAFE",
+  "categories": ["safe"],
+  "scanId": "scan_def",
+  "latencyMs": 38,
+  "usage": { "input": 500, "output": 200, "total": 700 }
+}
+```
+
+## Related Hooks
+
+- [prisma-airs-audit](prisma-airs-audit.md) — Application-layer message audit
+- [prisma-airs-prompt-scan](prisma-airs-prompt-scan.md) — Full context scanning before prompt build
+- [prisma-airs-outbound](prisma-airs-outbound.md) — Response blocking/masking

--- a/prisma-airs-plugin/hooks/prisma-airs-llm-audit/HOOK.md
+++ b/prisma-airs-plugin/hooks/prisma-airs-llm-audit/HOOK.md
@@ -1,0 +1,21 @@
+---
+name: prisma-airs-llm-audit
+description: "Audit log LLM inputs and outputs through Prisma AIRS scanning"
+metadata: { "openclaw": { "emoji": "📋", "events": ["llm_input", "llm_output"] } }
+---
+
+# Prisma AIRS LLM Audit
+
+Scans the exact prompts sent to and responses received from the LLM through Prisma AIRS. Provides a complete audit trail at the LLM boundary.
+
+## Behavior
+
+This hook handles both `llm_input` and `llm_output` events. On input, it scans the assembled prompt (including system prompt). On output, it scans the concatenated assistant response texts. Results are logged as structured JSON audit entries.
+
+## Configuration
+
+- `llm_audit_mode`: Audit mode (default: `deterministic`). Options: `deterministic` / `off`
+
+## Return Value
+
+Fire-and-forget — returns void. Cannot block LLM calls.

--- a/prisma-airs-plugin/hooks/prisma-airs-llm-audit/handler.test.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-llm-audit/handler.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for prisma-airs-llm-audit hook handler (llm_input + llm_output)
+ *
+ * Fire-and-forget hooks that scan LLM I/O through AIRS for audit logging.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import handler from "./handler";
+
+// Mock the scanner module
+vi.mock("../../src/scanner", () => ({
+  scan: vi.fn(),
+  defaultPromptDetected: () => ({
+    injection: false,
+    dlp: false,
+    urlCats: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    topicViolation: false,
+  }),
+  defaultResponseDetected: () => ({
+    dlp: false,
+    urlCats: false,
+    dbSecurity: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    ungrounded: false,
+    topicViolation: false,
+  }),
+}));
+
+import { scan, defaultPromptDetected, defaultResponseDetected } from "../../src/scanner";
+const mockScan = vi.mocked(scan);
+
+describe("prisma-airs-llm-audit handler", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const allowResult = {
+    action: "allow" as const,
+    severity: "SAFE" as const,
+    categories: ["safe"],
+    scanId: "scan_123",
+    reportId: "report_456",
+    profileName: "default",
+    promptDetected: defaultPromptDetected(),
+    responseDetected: defaultResponseDetected(),
+    latencyMs: 50,
+    timeout: false,
+    hasError: false,
+    contentErrors: [],
+  };
+
+  const baseCtx = {
+    agentId: "agent-1",
+    sessionKey: "session-123",
+    sessionId: "sid-abc",
+    cfg: {
+      plugins: {
+        entries: {
+          "prisma-airs": {
+            config: {
+              profile_name: "default",
+              app_name: "test-app",
+              llm_audit_mode: "deterministic",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  describe("llm_input event", () => {
+    const inputEvent = {
+      hookEvent: "llm_input" as const,
+      runId: "run-1",
+      sessionId: "sid-abc",
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      systemPrompt: "You are a helpful assistant.",
+      prompt: "What is the weather today?",
+      historyMessages: [],
+      imagesCount: 0,
+    };
+
+    it("should scan prompt through AIRS", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(inputEvent, baseCtx);
+      expect(mockScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringContaining("What is the weather today?"),
+          profileName: "default",
+          appName: "test-app",
+        })
+      );
+    });
+
+    it("should include system prompt in scan content", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(inputEvent, baseCtx);
+      const scanCall = mockScan.mock.calls[0][0];
+      expect(scanCall.prompt).toContain("You are a helpful assistant.");
+    });
+
+    it("should log audit entry with model info", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(inputEvent, baseCtx);
+      expect(logSpy).toHaveBeenCalled();
+      const logCall = logSpy.mock.calls.find((c) => {
+        const parsed = JSON.parse(c[0] as string);
+        return parsed.event === "prisma_airs_llm_input_audit";
+      });
+      expect(logCall).toBeDefined();
+      const entry = JSON.parse(logCall![0] as string);
+      expect(entry.model).toBe("claude-sonnet-4-20250514");
+      expect(entry.provider).toBe("anthropic");
+      expect(entry.action).toBe("allow");
+    });
+
+    it("should log threat detection on non-allow", async () => {
+      mockScan.mockResolvedValue({
+        ...allowResult,
+        action: "block",
+        severity: "CRITICAL",
+        categories: ["prompt_injection"],
+      });
+      await handler(inputEvent, baseCtx);
+      const logCall = logSpy.mock.calls.find((c) => {
+        const parsed = JSON.parse(c[0] as string);
+        return parsed.event === "prisma_airs_llm_input_audit";
+      });
+      const entry = JSON.parse(logCall![0] as string);
+      expect(entry.action).toBe("block");
+      expect(entry.categories).toContain("prompt_injection");
+    });
+  });
+
+  describe("llm_output event", () => {
+    const outputEvent = {
+      hookEvent: "llm_output" as const,
+      runId: "run-1",
+      sessionId: "sid-abc",
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      assistantTexts: ["The weather today is sunny.", "Temperature is 72F."],
+      usage: {
+        input: 100,
+        output: 50,
+        total: 150,
+      },
+    };
+
+    it("should scan response through AIRS", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(outputEvent, baseCtx);
+      expect(mockScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response: expect.stringContaining("The weather today is sunny."),
+          profileName: "default",
+          appName: "test-app",
+        })
+      );
+    });
+
+    it("should concatenate multiple assistant texts", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(outputEvent, baseCtx);
+      const scanCall = mockScan.mock.calls[0][0];
+      expect(scanCall.response).toContain("Temperature is 72F.");
+    });
+
+    it("should log audit entry with usage info", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(outputEvent, baseCtx);
+      const logCall = logSpy.mock.calls.find((c) => {
+        const parsed = JSON.parse(c[0] as string);
+        return parsed.event === "prisma_airs_llm_output_audit";
+      });
+      expect(logCall).toBeDefined();
+      const entry = JSON.parse(logCall![0] as string);
+      expect(entry.usage).toEqual({ input: 100, output: 50, total: 150 });
+    });
+
+    it("should handle empty assistantTexts", async () => {
+      const emptyEvent = { ...outputEvent, assistantTexts: [] };
+      await handler(emptyEvent, baseCtx);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled mode", () => {
+    it("should skip scanning when llm_audit_mode is off", async () => {
+      const ctxOff = {
+        ...baseCtx,
+        cfg: {
+          plugins: {
+            entries: {
+              "prisma-airs": {
+                config: {
+                  ...baseCtx.cfg.plugins.entries["prisma-airs"].config,
+                  llm_audit_mode: "off",
+                },
+              },
+            },
+          },
+        },
+      };
+      const inputEvent = {
+        hookEvent: "llm_input" as const,
+        runId: "run-1",
+        sessionId: "sid-abc",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      };
+      await handler(inputEvent, ctxOff);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should log error on scan failure without throwing", async () => {
+      mockScan.mockRejectedValue(new Error("API timeout"));
+      const inputEvent = {
+        hookEvent: "llm_input" as const,
+        runId: "run-1",
+        sessionId: "sid-abc",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      };
+      // Should not throw
+      await handler(inputEvent, baseCtx);
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("unknown event type", () => {
+    it("should skip unknown hookEvent types", async () => {
+      const unknownEvent = {
+        hookEvent: "unknown_event" as string,
+        runId: "run-1",
+        sessionId: "sid-abc",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await handler(unknownEvent as any, baseCtx);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/prisma-airs-plugin/hooks/prisma-airs-llm-audit/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-llm-audit/handler.ts
@@ -1,0 +1,183 @@
+/**
+ * Prisma AIRS LLM Audit Logger (llm_input + llm_output)
+ *
+ * Fire-and-forget hooks that scan the exact LLM I/O through AIRS.
+ * Provides definitive audit trail at the LLM boundary.
+ *
+ * - llm_input: scans the prompt sent to the model
+ * - llm_output: scans the response received from the model
+ */
+
+import { scan, type ScanResult } from "../../src/scanner";
+
+// Discriminated union for both event types
+interface LlmInputEvent {
+  hookEvent: "llm_input";
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  systemPrompt?: string;
+  prompt: string;
+  historyMessages: unknown[];
+  imagesCount: number;
+}
+
+interface LlmOutputEvent {
+  hookEvent: "llm_output";
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  assistantTexts: string[];
+  lastAssistant?: unknown;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+}
+
+type LlmAuditEvent = LlmInputEvent | LlmOutputEvent;
+
+interface HookContext {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  cfg?: {
+    plugins?: {
+      entries?: {
+        "prisma-airs"?: {
+          config?: {
+            profile_name?: string;
+            app_name?: string;
+            llm_audit_mode?: string;
+          };
+        };
+      };
+    };
+  };
+}
+
+/**
+ * Handle llm_input event — scan prompt sent to LLM
+ */
+async function handleInput(event: LlmInputEvent, ctx: HookContext): Promise<void> {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
+  const profileName = cfg?.profile_name ?? "default";
+  const appName = cfg?.app_name ?? "openclaw";
+  const sessionKey = ctx.sessionKey ?? event.sessionId ?? "unknown";
+
+  // Build scan content: system prompt + user prompt
+  const parts: string[] = [];
+  if (event.systemPrompt) {
+    parts.push(`[system]: ${event.systemPrompt}`);
+  }
+  parts.push(event.prompt);
+  const content = parts.join("\n");
+
+  if (!content.trim()) return;
+
+  let result: ScanResult;
+  try {
+    result = await scan({ prompt: content, profileName, appName });
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: "prisma_airs_llm_input_error",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        runId: event.runId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+    return;
+  }
+
+  console.log(
+    JSON.stringify({
+      event: "prisma_airs_llm_input_audit",
+      timestamp: new Date().toISOString(),
+      sessionKey,
+      runId: event.runId,
+      provider: event.provider,
+      model: event.model,
+      action: result.action,
+      severity: result.severity,
+      categories: result.categories,
+      scanId: result.scanId,
+      reportId: result.reportId,
+      latencyMs: result.latencyMs,
+      promptDetected: result.promptDetected,
+    })
+  );
+}
+
+/**
+ * Handle llm_output event — scan response from LLM
+ */
+async function handleOutput(event: LlmOutputEvent, ctx: HookContext): Promise<void> {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
+  const profileName = cfg?.profile_name ?? "default";
+  const appName = cfg?.app_name ?? "openclaw";
+  const sessionKey = ctx.sessionKey ?? event.sessionId ?? "unknown";
+
+  // Concatenate assistant texts
+  const content = event.assistantTexts.join("\n");
+  if (!content.trim()) return;
+
+  let result: ScanResult;
+  try {
+    result = await scan({ response: content, profileName, appName });
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: "prisma_airs_llm_output_error",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        runId: event.runId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+    return;
+  }
+
+  console.log(
+    JSON.stringify({
+      event: "prisma_airs_llm_output_audit",
+      timestamp: new Date().toISOString(),
+      sessionKey,
+      runId: event.runId,
+      provider: event.provider,
+      model: event.model,
+      action: result.action,
+      severity: result.severity,
+      categories: result.categories,
+      scanId: result.scanId,
+      reportId: result.reportId,
+      latencyMs: result.latencyMs,
+      responseDetected: result.responseDetected,
+      usage: event.usage,
+    })
+  );
+}
+
+/**
+ * Main hook handler — dispatches based on hookEvent type
+ */
+const handler = async (event: LlmAuditEvent, ctx: HookContext): Promise<void> => {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
+  const mode = cfg?.llm_audit_mode ?? "deterministic";
+
+  if (mode === "off") return;
+
+  if (event.hookEvent === "llm_input") {
+    await handleInput(event, ctx);
+  } else if (event.hookEvent === "llm_output") {
+    await handleOutput(event, ctx);
+  }
+};
+
+export default handler;

--- a/prisma-airs-plugin/openclaw.plugin.json
+++ b/prisma-airs-plugin/openclaw.plugin.json
@@ -14,7 +14,8 @@
     "hooks/prisma-airs-outbound-block",
     "hooks/prisma-airs-tool-guard",
     "hooks/prisma-airs-prompt-scan",
-    "hooks/prisma-airs-tool-redact"
+    "hooks/prisma-airs-tool-redact",
+    "hooks/prisma-airs-llm-audit"
   ],
   "configSchema": {
     "type": "object",
@@ -89,6 +90,12 @@
         "enum": ["deterministic", "off"],
         "default": "deterministic",
         "description": "Tool redact mode: deterministic (redact PII/credentials from tool outputs before persistence), or off"
+      },
+      "llm_audit_mode": {
+        "type": "string",
+        "enum": ["deterministic", "off"],
+        "default": "deterministic",
+        "description": "LLM audit mode: deterministic (scan all LLM inputs/outputs through AIRS for audit logging), or off"
       },
       "fail_closed": {
         "type": "boolean",
@@ -176,6 +183,10 @@
     "tool_redact_mode": {
       "label": "Tool Redact Mode",
       "description": "deterministic: redact PII/credentials from tool outputs before session persistence; off: disabled"
+    },
+    "llm_audit_mode": {
+      "label": "LLM Audit Mode",
+      "description": "deterministic: scan all LLM inputs and outputs through AIRS for audit logging; off: disabled"
     },
     "fail_closed": {
       "label": "Fail Closed",


### PR DESCRIPTION
## Summary
- Adds `prisma-airs-llm-audit` hook handling both `llm_input` and `llm_output` events
- Scans exact LLM prompts and responses through AIRS for audit trail
- Structured JSON audit entries with model, provider, token usage, scan results

## Changes
- New hook: `hooks/prisma-airs-llm-audit/` (handler + 11 tests + HOOK.md)
- New docs: `docs/hooks/prisma-airs-llm-audit.md`
- Updated `openclaw.plugin.json`: registered hook, added `llm_audit_mode` config + UI hint
- Updated `docs/hooks/index.md`: 11 hooks total

## Test plan
- [x] 11 unit tests covering input/output scanning, audit logging, model info, usage, disabled mode, error handling
- [x] 155 total tests passing
- [x] Typecheck, lint, format all clean

Closes #28