### PR TITLE
feat: add post-execution tool output scanning via after_tool_call hook

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -1,6 +1,6 @@
 # Hooks Overview
 
-The Prisma AIRS plugin provides 11 security hooks that work together for defense-in-depth.
+The Prisma AIRS plugin provides 12 security hooks that work together for defense-in-depth.
 
 ## Hook Summary
 
@@ -17,6 +17,7 @@ The Prisma AIRS plugin provides 11 security hooks that work together for defense
 | [prisma-airs-tool-guard](prisma-airs-tool-guard.md)               | `before_tool_call`     | Scan tool inputs via AIRS       | Yes       |
 | [prisma-airs-tool-redact](prisma-airs-tool-redact.md)             | `tool_result_persist`  | Redact PII from tool outputs    | No\*\*\*  |
 | [prisma-airs-llm-audit](prisma-airs-llm-audit.md)                | `llm_input/llm_output` | Audit log LLM I/O              | No        |
+| [prisma-airs-tool-audit](prisma-airs-tool-audit.md)              | `after_tool_call`      | Audit log tool outputs          | No        |
 
 \*\*\*Modifies persisted message content — does not block tool execution
 
@@ -77,6 +78,7 @@ plugins:
       tool_guard_mode: "deterministic"        # prisma-airs-tool-guard
       tool_redact_mode: "deterministic"       # prisma-airs-tool-redact
       llm_audit_mode: "deterministic"         # prisma-airs-llm-audit
+      tool_audit_mode: "deterministic"        # prisma-airs-tool-audit
 ```
 
 ## Data Sharing
@@ -115,6 +117,7 @@ plugins:
       tool_guard_mode: "deterministic"
       tool_redact_mode: "deterministic"
       llm_audit_mode: "deterministic"
+      tool_audit_mode: "deterministic"
       dlp_mask_only: false # Block instead of mask
 ```
 

--- a/docs/hooks/prisma-airs-tool-audit.md
+++ b/docs/hooks/prisma-airs-tool-audit.md
@@ -1,0 +1,67 @@
+# prisma-airs-tool-audit
+
+Post-execution audit logging of tool outputs through Prisma AIRS.
+
+## Overview
+
+| Property      | Value                                               |
+| ------------- | --------------------------------------------------- |
+| **Event**     | `after_tool_call`                                   |
+| **Emoji**     | :mag_right:                                         |
+| **Can Block** | No (fire-and-forget)                                |
+| **Config**    | `tool_audit_mode`                                   |
+
+## Purpose
+
+This hook:
+
+1. Fires after tool execution completes
+2. Serializes the tool result to a scannable string
+3. Scans the result through AIRS using toolEvent content type
+4. Logs structured JSON audit entries with tool metadata and scan results
+5. Complements tool-guard (pre-execution) by auditing what tools actually returned
+
+## Why Post-Execution Auditing Matters
+
+The tool-guard hook scans inputs before execution, but cannot inspect what the tool returns. A tool might return sensitive data, malicious content, or policy-violating information that was not apparent from the input. This hook provides the audit trail for tool outputs.
+
+## Configuration
+
+```yaml
+plugins:
+  prisma-airs:
+    config:
+      tool_audit_mode: "deterministic" # default
+```
+
+## Audit Log Format
+
+```json
+{
+  "event": "prisma_airs_tool_output_audit",
+  "timestamp": "2025-01-01T00:00:00.000Z",
+  "sessionKey": "session-123",
+  "toolName": "Read",
+  "durationMs": 15,
+  "action": "allow",
+  "severity": "SAFE",
+  "categories": ["safe"],
+  "scanId": "scan_abc",
+  "latencyMs": 42
+}
+```
+
+## Behavior
+
+| Condition          | Result                           |
+| ------------------ | -------------------------------- |
+| Result present     | Scanned through AIRS, logged     |
+| No result / error  | Skipped (nothing to scan)        |
+| Mode = off         | Skipped                          |
+| Scan failure       | Error logged, execution unaffected |
+
+## Related Hooks
+
+- [prisma-airs-tool-guard](prisma-airs-tool-guard.md) — Pre-execution tool input scanning (can block)
+- [prisma-airs-tools](prisma-airs-tools.md) — Cache-based tool gating (can block)
+- [prisma-airs-tool-redact](prisma-airs-tool-redact.md) — DLP redaction before persistence

--- a/prisma-airs-plugin/hooks/prisma-airs-tool-audit/HOOK.md
+++ b/prisma-airs-plugin/hooks/prisma-airs-tool-audit/HOOK.md
@@ -1,0 +1,21 @@
+---
+name: prisma-airs-tool-audit
+description: "Audit log tool execution results through Prisma AIRS scanning"
+metadata: { "openclaw": { "emoji": "🔎", "events": ["after_tool_call"] } }
+---
+
+# Prisma AIRS Tool Audit
+
+Scans tool execution results through Prisma AIRS after tool completion. Provides audit trail of tool output threats.
+
+## Behavior
+
+This hook fires after a tool completes execution. It serializes the tool result, scans it through AIRS using toolEvent content type, and logs structured audit entries. Complements tool-guard (pre-execution) by scanning what tools actually returned.
+
+## Configuration
+
+- `tool_audit_mode`: Audit mode (default: `deterministic`). Options: `deterministic` / `off`
+
+## Return Value
+
+Fire-and-forget — returns void. Cannot block tool results.

--- a/prisma-airs-plugin/hooks/prisma-airs-tool-audit/handler.test.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-tool-audit/handler.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for prisma-airs-tool-audit hook handler (after_tool_call)
+ *
+ * Fire-and-forget hook that scans tool outputs through AIRS for audit logging.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import handler from "./handler";
+
+// Mock the scanner module
+vi.mock("../../src/scanner", () => ({
+  scan: vi.fn(),
+  defaultPromptDetected: () => ({
+    injection: false,
+    dlp: false,
+    urlCats: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    topicViolation: false,
+  }),
+  defaultResponseDetected: () => ({
+    dlp: false,
+    urlCats: false,
+    dbSecurity: false,
+    toxicContent: false,
+    maliciousCode: false,
+    agent: false,
+    ungrounded: false,
+    topicViolation: false,
+  }),
+}));
+
+import { scan, defaultPromptDetected, defaultResponseDetected } from "../../src/scanner";
+const mockScan = vi.mocked(scan);
+
+describe("prisma-airs-tool-audit handler", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const allowResult = {
+    action: "allow" as const,
+    severity: "SAFE" as const,
+    categories: ["safe"],
+    scanId: "scan_123",
+    reportId: "report_456",
+    profileName: "default",
+    promptDetected: defaultPromptDetected(),
+    responseDetected: defaultResponseDetected(),
+    latencyMs: 50,
+    timeout: false,
+    hasError: false,
+    contentErrors: [],
+  };
+
+  const baseCtx = {
+    agentId: "agent-1",
+    sessionKey: "session-123",
+    sessionId: "sid-abc",
+    cfg: {
+      plugins: {
+        entries: {
+          "prisma-airs": {
+            config: {
+              profile_name: "default",
+              app_name: "test-app",
+              tool_audit_mode: "deterministic",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const baseEvent = {
+    toolName: "Read",
+    params: { file_path: "/etc/passwd" },
+    result: "root:x:0:0:root:/root:/bin/bash",
+    durationMs: 15,
+  };
+
+  describe("successful scan", () => {
+    it("should scan tool result through AIRS", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(baseEvent, baseCtx);
+      expect(mockScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response: expect.stringContaining("root:x:0:0"),
+          profileName: "default",
+          appName: "test-app",
+        })
+      );
+    });
+
+    it("should include toolEvents in scan request", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(baseEvent, baseCtx);
+      const scanCall = mockScan.mock.calls[0][0];
+      expect(scanCall.toolEvents).toBeDefined();
+      expect(scanCall.toolEvents![0].metadata.toolInvoked).toBe("Read");
+    });
+
+    it("should log audit entry with tool metadata", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      await handler(baseEvent, baseCtx);
+      const logCall = logSpy.mock.calls.find((c) => {
+        const parsed = JSON.parse(c[0] as string);
+        return parsed.event === "prisma_airs_tool_output_audit";
+      });
+      expect(logCall).toBeDefined();
+      const entry = JSON.parse(logCall![0] as string);
+      expect(entry.toolName).toBe("Read");
+      expect(entry.durationMs).toBe(15);
+      expect(entry.action).toBe("allow");
+    });
+
+    it("should log threat on non-allow result", async () => {
+      mockScan.mockResolvedValue({
+        ...allowResult,
+        action: "block",
+        severity: "HIGH",
+        categories: ["dlp_response"],
+      });
+      await handler(baseEvent, baseCtx);
+      const logCall = logSpy.mock.calls.find((c) => {
+        const parsed = JSON.parse(c[0] as string);
+        return parsed.event === "prisma_airs_tool_output_audit";
+      });
+      const entry = JSON.parse(logCall![0] as string);
+      expect(entry.action).toBe("block");
+      expect(entry.categories).toContain("dlp_response");
+    });
+  });
+
+  describe("result serialization", () => {
+    it("should handle object results", async () => {
+      mockScan.mockResolvedValue(allowResult);
+      const event = { ...baseEvent, result: { data: "value", count: 42 } };
+      await handler(event, baseCtx);
+      const scanCall = mockScan.mock.calls[0][0];
+      expect(scanCall.response).toContain("value");
+    });
+
+    it("should handle undefined result (error case)", async () => {
+      const event = { ...baseEvent, result: undefined, error: "File not found" };
+      await handler(event, baseCtx);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+
+    it("should handle null result", async () => {
+      const event = { ...baseEvent, result: null };
+      await handler(event, baseCtx);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled mode", () => {
+    it("should skip scanning when tool_audit_mode is off", async () => {
+      const ctxOff = {
+        ...baseCtx,
+        cfg: {
+          plugins: {
+            entries: {
+              "prisma-airs": {
+                config: {
+                  ...baseCtx.cfg.plugins.entries["prisma-airs"].config,
+                  tool_audit_mode: "off",
+                },
+              },
+            },
+          },
+        },
+      };
+      await handler(baseEvent, ctxOff);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should log error on scan failure without throwing", async () => {
+      mockScan.mockRejectedValue(new Error("API timeout"));
+      await handler(baseEvent, baseCtx);
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/prisma-airs-plugin/hooks/prisma-airs-tool-audit/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-tool-audit/handler.ts
@@ -1,0 +1,118 @@
+/**
+ * Prisma AIRS Tool Output Audit (after_tool_call)
+ *
+ * Fire-and-forget hook that scans tool execution results through AIRS.
+ * Provides audit trail of tool output threats — complements tool-guard (pre-execution).
+ */
+
+import { scan, type ScanResult } from "../../src/scanner";
+
+interface AfterToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+}
+
+interface HookContext {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  cfg?: {
+    plugins?: {
+      entries?: {
+        "prisma-airs"?: {
+          config?: {
+            profile_name?: string;
+            app_name?: string;
+            tool_audit_mode?: string;
+          };
+        };
+      };
+    };
+  };
+}
+
+/**
+ * Serialize tool result to string for scanning
+ */
+function serializeResult(result: unknown): string | undefined {
+  if (result === undefined || result === null) return undefined;
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return String(result);
+  }
+}
+
+/**
+ * Main hook handler — fire-and-forget audit of tool outputs
+ */
+const handler = async (event: AfterToolCallEvent, ctx: HookContext): Promise<void> => {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
+  const mode = cfg?.tool_audit_mode ?? "deterministic";
+
+  if (mode === "off") return;
+
+  // Serialize tool result
+  const resultStr = serializeResult(event.result);
+  if (!resultStr || !resultStr.trim()) return;
+
+  const profileName = cfg?.profile_name ?? "default";
+  const appName = cfg?.app_name ?? "openclaw";
+  const sessionKey = ctx.sessionKey ?? "unknown";
+
+  let scanResult: ScanResult;
+  try {
+    scanResult = await scan({
+      response: resultStr,
+      profileName,
+      appName,
+      toolEvents: [
+        {
+          metadata: {
+            ecosystem: "mcp",
+            method: "tool_result",
+            serverName: "local",
+            toolInvoked: event.toolName,
+          },
+          input: resultStr,
+        },
+      ],
+    });
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        event: "prisma_airs_tool_output_error",
+        timestamp: new Date().toISOString(),
+        sessionKey,
+        toolName: event.toolName,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+    return;
+  }
+
+  console.log(
+    JSON.stringify({
+      event: "prisma_airs_tool_output_audit",
+      timestamp: new Date().toISOString(),
+      sessionKey,
+      toolName: event.toolName,
+      durationMs: event.durationMs,
+      action: scanResult.action,
+      severity: scanResult.severity,
+      categories: scanResult.categories,
+      scanId: scanResult.scanId,
+      reportId: scanResult.reportId,
+      latencyMs: scanResult.latencyMs,
+      responseDetected: scanResult.responseDetected,
+    })
+  );
+};
+
+export default handler;

--- a/prisma-airs-plugin/openclaw.plugin.json
+++ b/prisma-airs-plugin/openclaw.plugin.json
@@ -15,7 +15,8 @@
     "hooks/prisma-airs-tool-guard",
     "hooks/prisma-airs-prompt-scan",
     "hooks/prisma-airs-tool-redact",
-    "hooks/prisma-airs-llm-audit"
+    "hooks/prisma-airs-llm-audit",
+    "hooks/prisma-airs-tool-audit"
   ],
   "configSchema": {
     "type": "object",
@@ -96,6 +97,12 @@
         "enum": ["deterministic", "off"],
         "default": "deterministic",
         "description": "LLM audit mode: deterministic (scan all LLM inputs/outputs through AIRS for audit logging), or off"
+      },
+      "tool_audit_mode": {
+        "type": "string",
+        "enum": ["deterministic", "off"],
+        "default": "deterministic",
+        "description": "Tool audit mode: deterministic (scan tool outputs through AIRS after execution), or off"
       },
       "fail_closed": {
         "type": "boolean",
@@ -187,6 +194,10 @@
     "llm_audit_mode": {
       "label": "LLM Audit Mode",
       "description": "deterministic: scan all LLM inputs and outputs through AIRS for audit logging; off: disabled"
+    },
+    "tool_audit_mode": {
+      "label": "Tool Audit Mode",
+      "description": "deterministic: scan tool execution results through AIRS for audit logging; off: disabled"
     },
     "fail_closed": {
       "label": "Fail Closed",


### PR DESCRIPTION
## Summary
- Adds `prisma-airs-tool-audit` hook on `after_tool_call` event
- Fire-and-forget scan of tool execution results through AIRS
- Structured JSON audit entries with tool metadata and scan results
- Complements tool-guard (pre-execution) for complete tool security coverage

## Changes
- New hook: `hooks/prisma-airs-tool-audit/` (handler + 9 tests + HOOK.md)
- New docs: `docs/hooks/prisma-airs-tool-audit.md`
- Updated `openclaw.plugin.json`: registered hook, added `tool_audit_mode` config + UI hint
- Updated `docs/hooks/index.md`: 12 hooks total

## Test plan
- [x] 9 unit tests covering scan, audit logging, result serialization, disabled mode, error handling
- [x] 164 total tests passing
- [x] Typecheck, lint, format all clean

Closes #29