### PR TITLE
chore: improve plugin UI hints with grouping, ordering, tags

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -62,23 +62,58 @@ flowchart TB
 
 ## Configuration
 
-Each hook can be individually configured via scanning modes:
+Each hook can be individually enabled or disabled. Settings are organized into groups in the web UI and can be searched by tags.
+
+### Connection
 
 ```yaml
 plugins:
   prisma-airs:
     config:
-      reminder_mode: "on"              # prisma-airs-guard (on / off)
-      audit_mode: "deterministic"      # prisma-airs-audit
-      context_injection_mode: "deterministic"  # prisma-airs-context
-      inbound_block_mode: "deterministic"      # prisma-airs-inbound-block
-      outbound_block_mode: "deterministic"    # prisma-airs-outbound-block
-      outbound_mode: "deterministic"          # prisma-airs-outbound
-      tool_gating_mode: "deterministic"       # prisma-airs-tools
-      tool_guard_mode: "deterministic"        # prisma-airs-tool-guard
-      tool_redact_mode: "deterministic"       # prisma-airs-tool-redact
-      llm_audit_mode: "deterministic"         # prisma-airs-llm-audit
-      tool_audit_mode: "deterministic"        # prisma-airs-tool-audit
+      api_key: "your-api-key"           # Required
+      profile_name: "default"            # AIRS profile from SCM
+      app_name: "openclaw"               # App name in scan metadata
+```
+
+### Blocking Hooks
+
+Hard guardrails that block content unless AIRS returns `allow`.
+
+```yaml
+      inbound_block_mode: "deterministic"    # Block unsafe user messages
+      outbound_block_mode: "deterministic"   # Block unsafe assistant messages
+      outbound_mode: "deterministic"         # Block/mask outbound responses
+      tool_guard_mode: "deterministic"       # Block tools with unsafe inputs
+      tool_gating_mode: "deterministic"      # Block tools via cached scan
+```
+
+### Scanning Hooks
+
+Inspect content and inject warnings or redact sensitive data.
+
+```yaml
+      prompt_scan_mode: "deterministic"      # Scan full conversation context
+      tool_redact_mode: "deterministic"      # Redact PII from tool outputs
+      context_injection_mode: "deterministic" # Inject threat warnings
+      reminder_mode: "on"                    # Security reminder on startup
+```
+
+### Audit Hooks
+
+Log scan results for compliance and monitoring (cannot block).
+
+```yaml
+      audit_mode: "deterministic"            # Message audit logging
+      llm_audit_mode: "deterministic"        # LLM I/O audit logging
+      tool_audit_mode: "deterministic"       # Tool output audit logging
+```
+
+### Advanced Settings
+
+```yaml
+      fail_closed: true                      # Block on scan failure
+      dlp_mask_only: true                    # Mask DLP instead of block
+      high_risk_tools: ["Bash", "Write"]     # Tools blocked on any threat
 ```
 
 ## Data Sharing
@@ -106,19 +141,24 @@ All hooks enabled, fail-closed:
 plugins:
   prisma-airs:
     config:
-      fail_closed: true
-      reminder_mode: "on"
-      audit_mode: "deterministic"
-      context_injection_mode: "deterministic"
+      # Blocking
       inbound_block_mode: "deterministic"
       outbound_block_mode: "deterministic"
       outbound_mode: "deterministic"
-      tool_gating_mode: "deterministic"
       tool_guard_mode: "deterministic"
+      tool_gating_mode: "deterministic"
+      # Scanning
+      prompt_scan_mode: "deterministic"
       tool_redact_mode: "deterministic"
+      context_injection_mode: "deterministic"
+      reminder_mode: "on"
+      # Audit
+      audit_mode: "deterministic"
       llm_audit_mode: "deterministic"
       tool_audit_mode: "deterministic"
-      dlp_mask_only: false # Block instead of mask
+      # Advanced
+      fail_closed: true
+      dlp_mask_only: false
 ```
 
 ### Audit Only
@@ -129,24 +169,42 @@ Log threats without enforcement:
 plugins:
   prisma-airs:
     config:
-      reminder_mode: "off"
-      audit_mode: "deterministic"
-      context_injection_mode: "off"
+      # Blocking — all off
+      inbound_block_mode: "off"
+      outbound_block_mode: "off"
       outbound_mode: "off"
+      tool_guard_mode: "off"
       tool_gating_mode: "off"
+      # Scanning — off
+      prompt_scan_mode: "off"
+      tool_redact_mode: "off"
+      context_injection_mode: "off"
+      reminder_mode: "off"
+      # Audit — enabled
+      audit_mode: "deterministic"
+      llm_audit_mode: "deterministic"
+      tool_audit_mode: "deterministic"
 ```
 
-### Outbound Only
+### Blocking Only
 
-Only scan responses:
+Block threats, no audit logging:
 
 ```yaml
 plugins:
   prisma-airs:
     config:
-      reminder_mode: "off"
-      audit_mode: "off"
-      context_injection_mode: "off"
+      # Blocking — enabled
+      inbound_block_mode: "deterministic"
+      outbound_block_mode: "deterministic"
       outbound_mode: "deterministic"
-      tool_gating_mode: "off"
+      tool_guard_mode: "deterministic"
+      tool_gating_mode: "deterministic"
+      # Scanning
+      prompt_scan_mode: "deterministic"
+      tool_redact_mode: "deterministic"
+      # Audit — off
+      audit_mode: "off"
+      llm_audit_mode: "off"
+      tool_audit_mode: "off"
 ```

--- a/prisma-airs-plugin/openclaw.plugin.json
+++ b/prisma-airs-plugin/openclaw.plugin.json
@@ -140,76 +140,137 @@
   "uiHints": {
     "api_key": {
       "label": "API Key",
+      "help": "Prisma AIRS API key from Strata Cloud Manager",
       "sensitive": true,
-      "placeholder": "Enter your PANW AI Security API key"
+      "placeholder": "Enter your PANW AI Security API key",
+      "group": "Connection",
+      "order": 1,
+      "tags": ["connection", "required"]
     },
     "profile_name": {
       "label": "Profile Name",
-      "placeholder": "default"
+      "help": "AIRS security profile from Strata Cloud Manager",
+      "placeholder": "default",
+      "group": "Connection",
+      "order": 2,
+      "tags": ["connection"]
     },
     "app_name": {
       "label": "Application Name",
-      "placeholder": "openclaw"
+      "help": "Identifies this application in AIRS scan metadata and audit logs",
+      "placeholder": "openclaw",
+      "group": "Connection",
+      "order": 3,
+      "tags": ["connection"]
     },
-    "reminder_mode": {
-      "label": "Reminder Mode",
-      "description": "on: inject scanning reminder at agent bootstrap; off: no reminder"
-    },
-    "audit_mode": {
-      "label": "Audit Mode",
-      "description": "deterministic: scan every inbound message via hook; probabilistic: model decides when to scan via tool; off: disabled"
-    },
-    "context_injection_mode": {
-      "label": "Context Injection Mode",
-      "description": "deterministic: always inject security context via hook; probabilistic: model decides when to scan via tool; off: disabled"
-    },
-    "outbound_mode": {
-      "label": "Outbound Scanning Mode",
-      "description": "deterministic: scan every outbound response via hook; probabilistic: model decides when to scan via tool; off: disabled"
-    },
-    "tool_gating_mode": {
-      "label": "Tool Gating Mode",
-      "description": "deterministic: always gate tool calls via hook; probabilistic: model checks tool safety via tool; off: disabled"
-    },
+
     "inbound_block_mode": {
-      "label": "Inbound Blocking Mode",
-      "description": "deterministic: block user messages unless AIRS returns allow; off: disabled"
+      "label": "Inbound Blocking",
+      "help": "Block user messages unless AIRS returns allow. Hard guardrail at the persistence layer.",
+      "group": "Blocking Hooks",
+      "order": 10,
+      "tags": ["blocking", "hook"]
     },
     "outbound_block_mode": {
-      "label": "Outbound Blocking Mode",
-      "description": "deterministic: block assistant messages at persistence layer unless AIRS returns allow; off: disabled"
+      "label": "Outbound Blocking",
+      "help": "Block assistant messages unless AIRS returns allow. Hard guardrail at the persistence layer.",
+      "group": "Blocking Hooks",
+      "order": 11,
+      "tags": ["blocking", "hook"]
+    },
+    "outbound_mode": {
+      "label": "Outbound Response Scanning",
+      "help": "Scan outbound responses — blocks or masks content based on AIRS verdict. Supports DLP masking.",
+      "group": "Blocking Hooks",
+      "order": 12,
+      "tags": ["blocking", "hook", "dlp"]
     },
     "tool_guard_mode": {
-      "label": "Tool Guard Mode",
-      "description": "deterministic: scan tool inputs through AIRS before execution; off: disabled"
+      "label": "Tool Input Scanning",
+      "help": "Scan tool inputs through AIRS before execution. Blocks tools when threats detected.",
+      "group": "Blocking Hooks",
+      "order": 13,
+      "tags": ["blocking", "hook", "tools"]
     },
+    "tool_gating_mode": {
+      "label": "Tool Gating (Cache-Based)",
+      "help": "Gate tool calls using cached scan results. Blocks high-risk tools when threats detected.",
+      "group": "Blocking Hooks",
+      "order": 14,
+      "tags": ["blocking", "hook", "tools"]
+    },
+
     "prompt_scan_mode": {
-      "label": "Prompt Scan Mode",
-      "description": "deterministic: scan full conversation context before prompt assembly; off: disabled"
+      "label": "Full Context Scanning",
+      "help": "Scan assembled conversation context before prompt build. Catches multi-message injection attacks.",
+      "group": "Scanning Hooks",
+      "order": 20,
+      "tags": ["scanning", "hook"]
     },
     "tool_redact_mode": {
-      "label": "Tool Redact Mode",
-      "description": "deterministic: redact PII/credentials from tool outputs before session persistence; off: disabled"
+      "label": "Tool Output Redaction",
+      "help": "Redact PII and credentials from tool outputs before session persistence (regex-based).",
+      "group": "Scanning Hooks",
+      "order": 21,
+      "tags": ["scanning", "hook", "dlp", "tools"]
+    },
+    "context_injection_mode": {
+      "label": "Context Injection",
+      "help": "Inject security threat warnings into agent context on startup.",
+      "group": "Scanning Hooks",
+      "order": 22,
+      "tags": ["scanning", "hook"]
+    },
+    "reminder_mode": {
+      "label": "Security Reminder",
+      "help": "Inject a security scanning reminder when the agent starts.",
+      "group": "Scanning Hooks",
+      "order": 23,
+      "tags": ["scanning", "hook"]
+    },
+
+    "audit_mode": {
+      "label": "Message Audit Logging",
+      "help": "Scan every inbound message through AIRS and log results. Populates scan cache for other hooks.",
+      "group": "Audit Hooks",
+      "order": 30,
+      "tags": ["audit", "hook"]
     },
     "llm_audit_mode": {
-      "label": "LLM Audit Mode",
-      "description": "deterministic: scan all LLM inputs and outputs through AIRS for audit logging; off: disabled"
+      "label": "LLM I/O Audit Logging",
+      "help": "Scan exact LLM prompts and responses through AIRS. Definitive audit trail at the model boundary.",
+      "group": "Audit Hooks",
+      "order": 31,
+      "tags": ["audit", "hook"]
     },
     "tool_audit_mode": {
-      "label": "Tool Audit Mode",
-      "description": "deterministic: scan tool execution results through AIRS for audit logging; off: disabled"
+      "label": "Tool Output Audit Logging",
+      "help": "Scan tool execution results through AIRS after completion. Complements tool input scanning.",
+      "group": "Audit Hooks",
+      "order": 32,
+      "tags": ["audit", "hook", "tools"]
     },
+
     "fail_closed": {
       "label": "Fail Closed",
-      "description": "Block on scan failure (recommended for security)"
+      "help": "Block messages when AIRS scan fails. Recommended for production security.",
+      "group": "Advanced Settings",
+      "order": 40,
+      "tags": ["advanced", "security"]
     },
     "dlp_mask_only": {
       "label": "DLP Mask Only",
-      "description": "Mask sensitive data instead of blocking"
+      "help": "Mask sensitive data instead of blocking when DLP is the only violation.",
+      "group": "Advanced Settings",
+      "order": 41,
+      "tags": ["advanced", "dlp"]
     },
     "high_risk_tools": {
       "label": "High Risk Tools",
-      "description": "Tools blocked on any threat detection"
+      "help": "Tools that are blocked on any detected threat. Add tool names to expand the list.",
+      "group": "Advanced Settings",
+      "order": 42,
+      "tags": ["advanced", "tools"]
     }
   },
   "requires": {}


### PR DESCRIPTION
## Summary
- Organize 16 config fields into 5 logical groups: Connection, Blocking Hooks, Scanning Hooks, Audit Hooks, Advanced Settings
- Add `order` values so fields sort logically (connection first → blocking → scanning → audit → advanced)
- Add `tags` for search filtering (`blocking`, `audit`, `scanning`, `tools`, `dlp`, `connection`, `advanced`)
- Add `group` for semantic grouping (future OpenClaw support)
- Switch `description` → `help` for OpenClaw renderer compatibility
- Update docs with grouped configuration sections and improved recommended configs

## Changes
- `openclaw.plugin.json`: restructured all 16 `uiHints` entries with group/order/tags/help
- `docs/hooks/index.md`: rewritten config section with grouped examples, added "Blocking Only" preset

## Test plan
- [x] 164 tests passing
- [x] Typecheck, lint, format all clean
- [x] JSON schema validates correctly

Closes #34