### PR TITLE
refactor: remove duplicate hook registrations from index.ts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,14 @@ services:
     volumes:
       - openclaw-data:/home/node/.openclaw
       - ./prisma-airs-plugin:/home/node/workspace/skills/prisma-airs-plugin
+    init: true
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "openclaw", "gateway", "health"]
-      interval: 5s
+      test: ["CMD", "curl", "-sf", "http://localhost:18789/__openclaw__/canvas/"]
+      interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 15s
+      start_period: 30s
 
 volumes:
   openclaw-data:

--- a/prisma-airs-plugin/hooks/prisma-airs-audit/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-audit/handler.ts
@@ -44,6 +44,7 @@ interface PluginConfig {
           profile_name?: string;
           app_name?: string;
           api_key?: string;
+          audit_mode?: string;
           fail_closed?: boolean;
         };
       };
@@ -55,14 +56,14 @@ interface PluginConfig {
  * Get plugin configuration
  */
 function getPluginConfig(ctx: HookContext & { cfg?: PluginConfig }): {
-  enabled: boolean;
+  mode: string;
   profileName: string;
   appName: string;
   failClosed: boolean;
 } {
   const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
   return {
-    enabled: true,
+    mode: cfg?.audit_mode ?? "deterministic",
     profileName: cfg?.profile_name ?? "default",
     appName: cfg?.app_name ?? "openclaw",
     failClosed: cfg?.fail_closed ?? true, // Default fail-closed
@@ -79,7 +80,7 @@ const handler = async (
   const config = getPluginConfig(ctx);
 
   // Check if audit is enabled
-  if (!config.enabled) {
+  if (config.mode === "off") {
     return;
   }
 

--- a/prisma-airs-plugin/hooks/prisma-airs-context/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-context/handler.ts
@@ -50,6 +50,7 @@ interface PluginConfig {
           profile_name?: string;
           app_name?: string;
           api_key?: string;
+          context_injection_mode?: string;
           fail_closed?: boolean;
         };
       };
@@ -136,14 +137,14 @@ const THREAT_INSTRUCTIONS: Record<string, string> = {
  * Get plugin configuration
  */
 function getPluginConfig(ctx: HookContext): {
-  enabled: boolean;
+  mode: string;
   profileName: string;
   appName: string;
   failClosed: boolean;
 } {
   const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
   return {
-    enabled: true,
+    mode: cfg?.context_injection_mode ?? "deterministic",
     profileName: cfg?.profile_name ?? "default",
     appName: cfg?.app_name ?? "openclaw",
     failClosed: cfg?.fail_closed ?? true, // Default fail-closed
@@ -245,7 +246,7 @@ const handler = async (
   const config = getPluginConfig(ctx);
 
   // Check if context injection is enabled
-  if (!config.enabled) {
+  if (config.mode === "off") {
     return;
   }
 

--- a/prisma-airs-plugin/hooks/prisma-airs-guard/handler.test.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-guard/handler.test.ts
@@ -5,158 +5,85 @@
 import { describe, it, expect } from "vitest";
 import handler, { buildReminder, DETERMINISTIC_REMINDER, PROBABILISTIC_REMINDER } from "./handler";
 
-interface BootstrapFile {
-  path: string;
-  content: string;
-  source?: string;
-}
-
-interface TestContext {
-  bootstrapFiles?: BootstrapFile[];
-  cfg?: Record<string, unknown>;
-}
-
-interface TestEvent {
-  type: string;
-  action: string;
-  context?: TestContext;
+function makeCtx(config?: Record<string, unknown>) {
+  return {
+    cfg: {
+      plugins: {
+        entries: {
+          "prisma-airs": { config: config ?? {} },
+        },
+      },
+    },
+  };
 }
 
 describe("prisma-airs-guard hook", () => {
-  it("injects security reminder on agent bootstrap", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-      context: {
-        bootstrapFiles: [],
-        cfg: { plugins: { entries: { "prisma-airs": { config: {} } } } },
-      },
-    };
-
-    await handler(event);
-
-    const files = event.context!.bootstrapFiles!;
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("SECURITY.md");
-    expect(files[0].content).toContain("MANDATORY Security Scanning");
-    expect(files[0].source).toBe("prisma-airs-guard");
+  it("returns systemPrompt with deterministic reminder by default", async () => {
+    const result = await handler({}, makeCtx());
+    expect(result).toBeDefined();
+    expect(result!.systemPrompt).toContain("Security Scanning Active");
   });
 
-  it("appends to existing bootstrapFiles", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-      context: {
-        bootstrapFiles: [{ path: "EXISTING.md", content: "existing" }],
-        cfg: {},
-      },
-    };
-
-    await handler(event);
-
-    const files = event.context!.bootstrapFiles!;
-    expect(files).toHaveLength(2);
-    expect(files[0].path).toBe("EXISTING.md");
-    expect(files[1].path).toBe("SECURITY.md");
+  it("returns deterministic reminder when all modes are deterministic", async () => {
+    const result = await handler(
+      {},
+      makeCtx({
+        audit_mode: "deterministic",
+        context_injection_mode: "deterministic",
+        outbound_mode: "deterministic",
+        tool_gating_mode: "deterministic",
+      })
+    );
+    expect(result!.systemPrompt).toBe(DETERMINISTIC_REMINDER);
   });
 
-  it("ignores non-bootstrap events", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "shutdown",
-      context: { bootstrapFiles: [] },
-    };
-
-    await handler(event);
-
-    expect(event.context!.bootstrapFiles).toHaveLength(0);
+  it("returns undefined when reminder_mode is off", async () => {
+    const result = await handler({}, makeCtx({ reminder_mode: "off" }));
+    expect(result).toBeUndefined();
   });
 
-  it("ignores non-agent events", async () => {
-    const event: TestEvent = {
-      type: "command",
-      action: "bootstrap",
-      context: { bootstrapFiles: [] },
-    };
-
-    await handler(event);
-
-    expect(event.context!.bootstrapFiles).toHaveLength(0);
+  it("returns systemPrompt when reminder_mode is on", async () => {
+    const result = await handler({}, makeCtx({ reminder_mode: "on" }));
+    expect(result).toBeDefined();
+    expect(result!.systemPrompt).toBeDefined();
   });
 
-  it("handles missing context gracefully", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-    };
-
-    // Should not throw
-    await expect(handler(event)).resolves.toBeUndefined();
+  it("handles missing config gracefully", async () => {
+    const result = await handler({}, {});
+    // Default reminder_mode is "on", should still return a reminder
+    expect(result).toBeDefined();
+    expect(result!.systemPrompt).toContain("Security Scanning");
   });
 
-  it("handles missing bootstrapFiles array", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-      context: { cfg: {} },
-    };
-
-    // Should not throw, just skip injection
-    await expect(handler(event)).resolves.toBeUndefined();
+  it("builds mode-aware reminder for probabilistic modes", async () => {
+    const result = await handler(
+      {},
+      makeCtx({
+        audit_mode: "probabilistic",
+        context_injection_mode: "probabilistic",
+        outbound_mode: "probabilistic",
+        tool_gating_mode: "probabilistic",
+        fail_closed: false,
+      })
+    );
+    expect(result!.systemPrompt).toContain("MANDATORY Security Scanning");
+    expect(result!.systemPrompt).toContain("prisma_airs_scan_prompt");
   });
 
-  it("injects by default when no config provided", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-      context: { bootstrapFiles: [] },
-    };
-
-    await handler(event);
-
-    expect(event.context!.bootstrapFiles).toHaveLength(1);
-  });
-
-  it("does not inject when reminder_mode is off", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-      context: {
-        bootstrapFiles: [],
-        cfg: {
-          plugins: {
-            entries: {
-              "prisma-airs": { config: { reminder_mode: "off" } },
-            },
-          },
-        },
-      },
-    };
-
-    await handler(event);
-    expect(event.context!.bootstrapFiles).toHaveLength(0);
-  });
-
-  it("injects when reminder_mode is on", async () => {
-    const event: TestEvent = {
-      type: "agent",
-      action: "bootstrap",
-      context: {
-        bootstrapFiles: [],
-        cfg: {
-          plugins: {
-            entries: {
-              "prisma-airs": {
-                config: { reminder_mode: "on" },
-              },
-            },
-          },
-        },
-      },
-    };
-
-    await handler(event);
-    expect(event.context!.bootstrapFiles).toHaveLength(1);
+  it("builds mixed mode reminder", async () => {
+    const result = await handler(
+      {},
+      makeCtx({
+        audit_mode: "deterministic",
+        context_injection_mode: "deterministic",
+        outbound_mode: "probabilistic",
+        tool_gating_mode: "off",
+        fail_closed: false,
+      })
+    );
+    expect(result!.systemPrompt).toContain("Mixed Mode");
+    expect(result!.systemPrompt).toContain("Audit logging");
+    expect(result!.systemPrompt).toContain("prisma_airs_scan_response");
   });
 });
 
@@ -210,7 +137,7 @@ describe("buildReminder", () => {
       outbound: "off",
       toolGating: "off",
     });
-    // All off → no probabilistic → deterministic reminder (empty deterministic list but still deterministic path)
+    // All off → no probabilistic → deterministic reminder
     expect(text).toBe(DETERMINISTIC_REMINDER);
   });
 });

--- a/prisma-airs-plugin/hooks/prisma-airs-guard/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-guard/handler.ts
@@ -1,33 +1,35 @@
 /**
- * Prisma AIRS Security Reminder Hook
+ * Prisma AIRS Security Reminder Hook (before_agent_start)
  *
  * Injects security scanning reminder into agent bootstrap context.
  * Supports deterministic vs probabilistic mode-aware reminders.
+ * Self-contained: resolves modes from plugin config, no external registration needed.
  */
 
 import type { FeatureMode, ResolvedModes } from "../../src/config";
+import { resolveAllModes, type RawPluginConfig } from "../../src/config";
 
-// Types for OpenClaw hook system
-interface BootstrapFile {
-  path: string;
-  content: string;
-  source?: string;
+// Hook context from OpenClaw
+interface HookContext {
+  cfg?: {
+    plugins?: {
+      entries?: {
+        "prisma-airs"?: {
+          config?: RawPluginConfig & {
+            profile_name?: string;
+            app_name?: string;
+            api_key?: string;
+          };
+        };
+      };
+    };
+  };
 }
 
-interface AgentBootstrapContext {
-  workspaceDir?: string;
-  bootstrapFiles?: BootstrapFile[];
-  cfg?: Record<string, unknown>;
+// Hook result type
+interface HookResult {
+  systemPrompt?: string;
 }
-
-interface HookEvent {
-  type: string;
-  action: string;
-  context?: AgentBootstrapContext;
-  messages?: string[];
-}
-
-type HookHandler = (event: HookEvent) => Promise<void> | void;
 
 export const DETERMINISTIC_REMINDER = `# Security Scanning Active
 
@@ -144,37 +146,36 @@ Failure to scan suspicious content is a security violation.
 `;
 }
 
-// Legacy reminder (kept for backward compat when called without modes)
-const SECURITY_REMINDER = PROBABILISTIC_REMINDER;
+/**
+ * Main hook handler — auto-discovered by OpenClaw from HOOK.md
+ * Resolves modes from plugin config, builds mode-aware reminder, returns { systemPrompt }
+ */
+const handler = async (_event: unknown, ctx: HookContext): Promise<HookResult | void> => {
+  const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
 
-const handler: HookHandler = async (event: HookEvent) => {
-  // Only handle agent bootstrap events
-  if (event.type !== "agent" || event.action !== "bootstrap") {
-    return;
-  }
-
-  // Get plugin config from context.cfg
-  const cfg = event.context?.cfg as Record<string, unknown> | undefined;
-  const plugins = cfg?.plugins as Record<string, unknown> | undefined;
-  const entries = plugins?.entries as Record<string, unknown> | undefined;
-  const prismaConfig = entries?.["prisma-airs"] as Record<string, unknown> | undefined;
-  const pluginSettings = prismaConfig?.config as Record<string, unknown> | undefined;
-
-  // Check if reminder is enabled (default true)
-  const reminderMode = pluginSettings?.reminder_mode as string | undefined;
-
+  // Check if reminder is enabled (default: on)
+  const reminderMode = cfg?.reminder_mode ?? "on";
   if (reminderMode === "off") {
     return;
   }
 
-  // Inject security reminder as a bootstrap file
-  if (event.context && Array.isArray(event.context.bootstrapFiles)) {
-    event.context.bootstrapFiles.push({
-      path: "SECURITY.md",
-      content: SECURITY_REMINDER,
-      source: "prisma-airs-guard",
-    });
+  // Resolve all modes from config to build mode-aware reminder
+  let modes: ResolvedModes;
+  try {
+    modes = resolveAllModes(cfg ?? {});
+  } catch {
+    // If mode resolution fails, use deterministic reminder as safe default
+    modes = {
+      reminder: "on",
+      audit: "deterministic",
+      context: "deterministic",
+      outbound: "deterministic",
+      toolGating: "deterministic",
+    };
   }
+
+  const reminderText = buildReminder(modes);
+  return { systemPrompt: reminderText };
 };
 
 export default handler;

--- a/prisma-airs-plugin/hooks/prisma-airs-outbound/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-outbound/handler.ts
@@ -43,6 +43,7 @@ interface PluginConfig {
           profile_name?: string;
           app_name?: string;
           api_key?: string;
+          outbound_mode?: string;
           fail_closed?: boolean;
           dlp_mask_only?: boolean;
         };
@@ -119,7 +120,7 @@ const ALWAYS_BLOCK_CATEGORIES = [
  * Get plugin configuration
  */
 function getPluginConfig(ctx: HookContext): {
-  enabled: boolean;
+  mode: string;
   profileName: string;
   appName: string;
   failClosed: boolean;
@@ -127,7 +128,7 @@ function getPluginConfig(ctx: HookContext): {
 } {
   const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
   return {
-    enabled: true,
+    mode: cfg?.outbound_mode ?? "deterministic",
     profileName: cfg?.profile_name ?? "default",
     appName: cfg?.app_name ?? "openclaw",
     failClosed: cfg?.fail_closed ?? true, // Default fail-closed
@@ -235,7 +236,7 @@ const handler = async (
   const config = getPluginConfig(ctx);
 
   // Check if outbound scanning is enabled
-  if (!config.enabled) {
+  if (config.mode === "off") {
     return;
   }
 

--- a/prisma-airs-plugin/hooks/prisma-airs-tools/handler.ts
+++ b/prisma-airs-plugin/hooks/prisma-airs-tools/handler.ts
@@ -30,6 +30,7 @@ interface PluginConfig {
     entries?: {
       "prisma-airs"?: {
         config?: {
+          tool_gating_mode?: string;
           high_risk_tools?: string[];
           api_key?: string;
         };
@@ -143,12 +144,12 @@ export const DEFAULT_HIGH_RISK_TOOLS = [
  * Get plugin configuration
  */
 function getPluginConfig(ctx: HookContext): {
-  enabled: boolean;
+  mode: string;
   highRiskTools: string[];
 } {
   const cfg = ctx.cfg?.plugins?.entries?.["prisma-airs"]?.config;
   return {
-    enabled: true,
+    mode: cfg?.tool_gating_mode ?? "deterministic",
     highRiskTools: cfg?.high_risk_tools ?? DEFAULT_HIGH_RISK_TOOLS,
   };
 }
@@ -210,7 +211,7 @@ const handler = async (
   const config = getPluginConfig(ctx);
 
   // Check if tool gating is enabled
-  if (!config.enabled) {
+  if (config.mode === "off") {
     return;
   }
 

--- a/prisma-airs-plugin/index.ts
+++ b/prisma-airs-plugin/index.ts
@@ -4,22 +4,20 @@
  * AI Runtime Security scanning via Palo Alto Networks.
  * Uses @cdot65/prisma-airs-sdk for AIRS API communication.
  *
- * Provides:
- * - Gateway RPC method: prisma-airs.scan
+ * Hooks are auto-discovered by OpenClaw from HOOK.md files in the hooks/ directory.
+ * Each hook handler self-checks its mode and accesses config via ctx.cfg.
+ *
+ * This file provides:
+ * - SDK initialization (api_key)
+ * - Gateway RPC methods: prisma-airs.status, prisma-airs.scan
  * - Agent tool: prisma_airs_scan (always registered)
  * - Probabilistic tools: prisma_airs_scan_prompt, prisma_airs_scan_response, prisma_airs_check_tool_safety
- * - Bootstrap hook: prisma-airs-guard (mode-aware reminder)
- * - Deterministic hooks: audit, context, outbound, tools (conditional)
+ * - CLI commands: prisma-airs, prisma-airs-scan
  */
 
 import { init } from "@cdot65/prisma-airs-sdk";
 import { scan, isConfigured, ScanRequest } from "./src/scanner";
 import { resolveAllModes, type RawPluginConfig, type ResolvedModes } from "./src/config";
-import { buildReminder } from "./hooks/prisma-airs-guard/handler";
-import auditHandler from "./hooks/prisma-airs-audit/handler";
-import contextHandler from "./hooks/prisma-airs-context/handler";
-import outboundHandler from "./hooks/prisma-airs-outbound/handler";
-import toolsHandler from "./hooks/prisma-airs-tools/handler";
 import {
   maskSensitiveData,
   shouldMaskOnly,
@@ -89,8 +87,6 @@ interface PluginApi {
     execute: (_id: string, params: Record<string, unknown>) => Promise<ToolResult>;
   }) => void;
   registerCli: (setup: (ctx: { program: unknown }) => void, opts: { commands: string[] }) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  on: (hookName: string, handler: (...args: any[]) => any, opts?: { priority?: number }) => void;
 }
 
 // Get plugin config from OpenClaw config
@@ -147,70 +143,10 @@ export default function register(api: PluginApi): void {
     `Prisma AIRS plugin loaded (audit=${modes.audit}, context=${modes.context}, outbound=${modes.outbound}, toolGating=${modes.toolGating}, reminder=${modes.reminder})`
   );
 
-  // ── DETERMINISTIC HOOKS ──────────────────────────────────────────────
-
-  // Guard: inject mode-aware security reminder at agent bootstrap
-  if (modes.reminder === "on") {
-    api.on(
-      "before_agent_start",
-      async () => {
-        const reminderText = buildReminder(modes);
-        return { systemPrompt: reminderText };
-      },
-      { priority: 100 }
-    );
-  }
-
-  // Audit: fire-and-forget inbound message scan logging
-  if (modes.audit === "deterministic") {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    api.on("message_received", async (event: any, ctx: any) => {
-      await auditHandler(event, { ...ctx, cfg: api.config });
-    });
-  }
-
-  // Context: inject security warnings before agent processes message
-  if (modes.context === "deterministic") {
-    api.on(
-      "before_agent_start",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async (event: any, ctx: any) => {
-        return await contextHandler(
-          {
-            sessionKey: ctx.sessionKey,
-            message: { content: event.prompt },
-            messages: event.messages,
-          },
-          { ...ctx, cfg: api.config }
-        );
-      },
-      { priority: 50 }
-    );
-  }
-
-  // Outbound: scan and block/mask outgoing responses
-  if (modes.outbound === "deterministic") {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    api.on("message_sending", async (event: any, ctx: any) => {
-      return await outboundHandler(event, { ...ctx, cfg: api.config });
-    });
-  }
-
-  // Tools: block dangerous tool calls during active threats
-  if (modes.toolGating === "deterministic") {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    api.on("before_tool_call", async (event: any, ctx: any) => {
-      return await toolsHandler(event, { ...ctx, cfg: api.config });
-    });
-  }
-
-  const hookCount =
-    (modes.reminder === "on" ? 1 : 0) +
-    (modes.audit === "deterministic" ? 1 : 0) +
-    (modes.context === "deterministic" ? 1 : 0) +
-    (modes.outbound === "deterministic" ? 1 : 0) +
-    (modes.toolGating === "deterministic" ? 1 : 0);
-  api.logger.info(`Registered ${hookCount} deterministic hooks`);
+  // ── HOOKS ────────────────────────────────────────────────────────────
+  // All 12 hooks are auto-discovered by OpenClaw from HOOK.md files.
+  // Each handler checks its own mode and accesses config via ctx.cfg.
+  // No api.on() registrations needed.
 
   // ── PROBABILISTIC TOOLS ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Remove 5 duplicate `api.on()` hook registrations from `index.ts` — OpenClaw auto-discovers all 12 hooks from `HOOK.md` files
- Add self-contained mode checks to audit, context, outbound, and tools handlers (previously gated by `index.ts`)
- Rewrite guard handler to resolve modes from `ctx.cfg` and return `{ systemPrompt }` instead of legacy `bootstrapFiles.push()`
- Fix Docker healthcheck (curl-based instead of hanging `openclaw gateway health`, add `init: true`)

Closes #36

## Test plan

- [x] 162 tests pass (all 12 test files)
- [x] Typecheck, lint, format clean
- [ ] Docker: verify hooks load once (no duplicates in logs)
- [ ] Verify guard reminder still injected on agent start

🤖 Generated with [Claude Code](https://claude.com/claude-code)